### PR TITLE
Fix log4j2 error with some specific jdk versions.

### DIFF
--- a/arclight-common/src/main/java/io/izzel/arclight/common/ArclightMain.java
+++ b/arclight-common/src/main/java/io/izzel/arclight/common/ArclightMain.java
@@ -19,10 +19,10 @@ import java.util.jar.Manifest;
 public abstract class ArclightMain {
 
     public void run(String[] args) throws Throwable {
+        System.setProperty("java.util.logging.manager", ArclightLazyLogManager.class.getCanonicalName());
         System.setProperty("log4j.jul.LoggerAdapter", "io.izzel.arclight.common.mod.util.log.ArclightLoggerAdapter");
         ArclightLocale.info("i18n.using-language", ArclightConfig.spec().getLocale().getCurrent(), ArclightConfig.spec().getLocale().getFallback());
         this.afterSetup();
-        System.setProperty("java.util.logging.manager", ArclightLazyLogManager.initClass().getCanonicalName());
         try { // Java 9 & Java 兼容性
             int javaVersion = (int) Float.parseFloat(System.getProperty("java.class.version"));
             if (javaVersion == 53) {

--- a/arclight-common/src/main/java/io/izzel/arclight/common/ArclightMain.java
+++ b/arclight-common/src/main/java/io/izzel/arclight/common/ArclightMain.java
@@ -19,10 +19,10 @@ import java.util.jar.Manifest;
 public abstract class ArclightMain {
 
     public void run(String[] args) throws Throwable {
-        System.setProperty("java.util.logging.manager", ArclightLazyLogManager.class.getCanonicalName());
         System.setProperty("log4j.jul.LoggerAdapter", "io.izzel.arclight.common.mod.util.log.ArclightLoggerAdapter");
         ArclightLocale.info("i18n.using-language", ArclightConfig.spec().getLocale().getCurrent(), ArclightConfig.spec().getLocale().getFallback());
         this.afterSetup();
+        System.setProperty("java.util.logging.manager", ArclightLazyLogManager.initClass().getCanonicalName());
         try { // Java 9 & Java 兼容性
             int javaVersion = (int) Float.parseFloat(System.getProperty("java.class.version"));
             if (javaVersion == 53) {

--- a/arclight-common/src/main/java/io/izzel/arclight/common/mod/util/log/ArclightI18nLogger.java
+++ b/arclight-common/src/main/java/io/izzel/arclight/common/mod/util/log/ArclightI18nLogger.java
@@ -17,12 +17,7 @@ public class ArclightI18nLogger extends ExtendedLoggerWrapper {
     }
 
     public static Logger getLogger(String name) {
-        for (int i = 0; i < 10; i++) {
-            try {
-                return new ArclightI18nLogger((ExtendedLogger) LogManager.getLogger(name));
-            } catch (Throwable ignored) {}
-        }
-        throw new IllegalStateException("wtf");
+        return new ArclightI18nLogger((ExtendedLogger) LogManager.getLogger(name));
     }
 
     @Override

--- a/arclight-common/src/main/java/io/izzel/arclight/common/mod/util/log/ArclightLazyLogManager.java
+++ b/arclight-common/src/main/java/io/izzel/arclight/common/mod/util/log/ArclightLazyLogManager.java
@@ -6,7 +6,7 @@ import java.util.logging.Logger;
 
 public class ArclightLazyLogManager extends LogManager {
 
-    private static volatile LogManager delegate;
+    private volatile LogManager delegate;
 
     @Override
     public boolean addLogger(Logger logger) {
@@ -18,8 +18,8 @@ public class ArclightLazyLogManager extends LogManager {
     @Override
     public Logger getLogger(String name) {
         tryGet();
-        if (delegate != null) return delegate.getLogger(name);
-        return super.getLogger(name);
+        if (delegate != null && !"jdk.event.security".equals(name)) return delegate.getLogger(name);
+        return Logger.getGlobal();
     }
 
     @Override
@@ -29,12 +29,7 @@ public class ArclightLazyLogManager extends LogManager {
         return super.getLoggerNames();
     }
 
-    public static Class<ArclightLazyLogManager> initClass() {
-        tryGet();
-        return ArclightLazyLogManager.class;
-    }
-
-    private static void tryGet() {
+    private void tryGet() {
         if (delegate != null) return;
         try {
             Class<?> name = Class.forName("org.apache.logging.log4j.jul.LogManager");

--- a/arclight-common/src/main/java/io/izzel/arclight/common/mod/util/log/ArclightLazyLogManager.java
+++ b/arclight-common/src/main/java/io/izzel/arclight/common/mod/util/log/ArclightLazyLogManager.java
@@ -6,7 +6,7 @@ import java.util.logging.Logger;
 
 public class ArclightLazyLogManager extends LogManager {
 
-    private volatile LogManager delegate;
+    private static volatile LogManager delegate;
 
     @Override
     public boolean addLogger(Logger logger) {
@@ -29,7 +29,12 @@ public class ArclightLazyLogManager extends LogManager {
         return super.getLoggerNames();
     }
 
-    private void tryGet() {
+    public static Class<ArclightLazyLogManager> initClass() {
+        tryGet();
+        return ArclightLazyLogManager.class;
+    }
+
+    private static void tryGet() {
         if (delegate != null) return;
         try {
             Class<?> name = Class.forName("org.apache.logging.log4j.jul.LogManager");


### PR DESCRIPTION

arclight-1.16.4-1.0.9-SNAPSHOT-9d06987 will crash on launch with Oracle JDK 8u231+ and Azul Zulu JDK 8u232+, this pr can fix it.

![OA051HFH8X )4UF4C18)JDR](https://user-images.githubusercontent.com/41327811/99893135-4f89cb80-2cb7-11eb-9000-5df5ca7e9cf8.png)
