### PR TITLE
Fix logger error with some specific jdk versions again.

### DIFF
--- a/arclight-common/src/main/java/io/izzel/arclight/common/mod/util/log/ArclightLazyLogManager.java
+++ b/arclight-common/src/main/java/io/izzel/arclight/common/mod/util/log/ArclightLazyLogManager.java
@@ -6,11 +6,13 @@ import java.util.logging.Logger;
 
 public class ArclightLazyLogManager extends LogManager {
 
+    private static final String SECURITY_LOGGER_NAME = "jdk.event.security";
     private volatile LogManager delegate;
 
     @Override
     public boolean addLogger(Logger logger) {
         tryGet();
+        if (SECURITY_LOGGER_NAME.equals(logger.getName())) return true;
         if (delegate != null) return delegate.addLogger(logger);
         return super.addLogger(logger);
     }
@@ -18,7 +20,7 @@ public class ArclightLazyLogManager extends LogManager {
     @Override
     public Logger getLogger(String name) {
         tryGet();
-        if (delegate != null && !"jdk.event.security".equals(name)) return delegate.getLogger(name);
+        if (delegate != null && !SECURITY_LOGGER_NAME.equals(name)) return delegate.getLogger(name);
         return Logger.getGlobal();
     }
 


### PR DESCRIPTION
Fix the error which introduced by https://github.com/IzzelAliz/Arclight/pull/83 when launching with openjdk 11 
```
Exception in thread "main" java.lang.InternalError: invalid logger merge
        at java.logging/java.util.logging.Logger.mergeWithSystemLogger(Logger.java:579)
        at java.logging/java.util.logging.LogManager$3.run(LogManager.java:582)
        at java.logging/java.util.logging.LogManager$3.run(LogManager.java:579)
        at java.base/java.security.AccessController.doPrivileged(Native Method)
        at java.logging/java.util.logging.LogManager.demandSystemLogger(LogManager.java:579)
        at java.logging/java.util.logging.LogManager$LoggingProviderAccess.demandLoggerFor(LogManager.java:2710)
        at java.logging/sun.util.logging.internal.LoggingProviderImpl.demandJULLoggerFor(LoggingProviderImpl.java:411)
        at java.logging/sun.util.logging.internal.LoggingProviderImpl.demandLoggerFor(LoggingProviderImpl.java:436)
        at java.base/jdk.internal.logger.DefaultLoggerFinder.getLogger(DefaultLoggerFinder.java:157)
        at java.base/jdk.internal.logger.LazyLoggers.getLoggerFromFinder(LazyLoggers.java:389)
        at java.base/jdk.internal.logger.LazyLoggers.getLazyLogger(LazyLoggers.java:444)
        at java.base/jdk.internal.logger.LazyLoggers.getLogger(LazyLoggers.java:414)
        at java.base/java.lang.System.getLogger(System.java:1662)
        at java.base/jdk.internal.event.EventHelper.isLoggingSecurity(EventHelper.java:145)
        at java.base/sun.security.provider.X509Factory.commitEvent(X509Factory.java:772)
        at java.base/sun.security.provider.X509Factory.engineGenerateCertificate(X509Factory.java:108)
        at java.base/java.security.cert.CertificateFactory.generateCertificate(CertificateFactory.java:355)
        at java.base/sun.security.pkcs.PKCS7.parseSignedData(PKCS7.java:328)
        at java.base/sun.security.pkcs.PKCS7.parse(PKCS7.java:186)
        at java.base/sun.security.pkcs.PKCS7.parse(PKCS7.java:154)
        at java.base/sun.security.pkcs.PKCS7.<init>(PKCS7.java:136)
        at java.base/sun.security.util.SignatureFileVerifier.<init>(SignatureFileVerifier.java:127)
        at java.base/java.util.jar.JarVerifier.processEntry(JarVerifier.java:297)
        at java.base/java.util.jar.JarVerifier.update(JarVerifier.java:230)
        at java.base/java.util.jar.JarFile.initializeVerifier(JarFile.java:759)
        at java.base/java.util.jar.JarFile.getInputStream(JarFile.java:840)
        at java.base/sun.net.www.protocol.jar.JarURLConnection.getInputStream(JarURLConnection.java:167)
        at java.base/java.net.URL.openStream(URL.java:1140)
        at org.apache.logging.log4j.core.config.plugins.processor.PluginCache.loadCacheFiles(PluginCache.java:100)
        at org.apache.logging.log4j.core.config.plugins.util.PluginRegistry.decodeCacheFiles(PluginRegistry.java:166)
        at org.apache.logging.log4j.core.config.plugins.util.PluginRegistry.loadFromMainClassLoader(PluginRegistry.java:119)
        at org.apache.logging.log4j.core.config.plugins.util.PluginManager.collectPlugins(PluginManager.java:132)
        at org.apache.logging.log4j.core.pattern.PatternParser.<init>(PatternParser.java:132)
        at org.apache.logging.log4j.core.pattern.PatternParser.<init>(PatternParser.java:113)
        at org.apache.logging.log4j.core.layout.PatternLayout.createPatternParser(PatternLayout.java:247)
        at org.apache.logging.log4j.core.layout.PatternLayout$SerializerBuilder.build(PatternLayout.java:376)
        at org.apache.logging.log4j.core.layout.PatternLayout.<init>(PatternLayout.java:129)
        at org.apache.logging.log4j.core.layout.PatternLayout.<init>(PatternLayout.java:59)
        at org.apache.logging.log4j.core.layout.PatternLayout$Builder.build(PatternLayout.java:660)
        at org.apache.logging.log4j.core.config.AbstractConfiguration.setToDefault(AbstractConfiguration.java:584)
        at org.apache.logging.log4j.core.config.DefaultConfiguration.<init>(DefaultConfiguration.java:47)
        at org.apache.logging.log4j.core.LoggerContext.<init>(LoggerContext.java:88)
        at org.apache.logging.log4j.core.selector.ClassLoaderContextSelector.createContext(ClassLoaderContextSelector.java:171)
        at org.apache.logging.log4j.core.selector.ClassLoaderContextSelector.locateContext(ClassLoaderContextSelector.java:145)
        at org.apache.logging.log4j.core.selector.ClassLoaderContextSelector.getContext(ClassLoaderContextSelector.java:74)
        at org.apache.logging.log4j.core.impl.Log4jContextFactory.getContext(Log4jContextFactory.java:228)
        at org.apache.logging.log4j.core.impl.Log4jContextFactory.getContext(Log4jContextFactory.java:45)
        at org.apache.logging.log4j.LogManager.getContext(LogManager.java:174)
        at org.apache.logging.log4j.LogManager.getLogger(LogManager.java:648)
        at io.izzel.arclight.common.mod.util.log.ArclightI18nLogger.getLogger(ArclightI18nLogger.java:20)
        at io.izzel.arclight.common.ArclightMain.printLogo(ArclightMain.java:62)
        at io.izzel.arclight.common.ArclightMain.run(ArclightMain.java:38)
        at io.izzel.arclight.server.Main_1_16.main(Main_1_16.java:10)
```