### PR TITLE
Replacing substring with replaceAll using regex

### DIFF
--- a/arclight-common/src/main/java/io/izzel/arclight/common/mixin/bukkit/CraftLegacyLegacyMixin.java
+++ b/arclight-common/src/main/java/io/izzel/arclight/common/mixin/bukkit/CraftLegacyLegacyMixin.java
@@ -85,7 +85,7 @@ public class CraftLegacyLegacyMixin {
         if (((MaterialBridge) (Object) material).bridge$getType() == MaterialPropertySpec.MaterialType.FORGE) {
             return material.name();
         } else {
-            return material.name().substring("LEGACY_".length());
+            return material.name().replaceAll("^LEGACY_", "");
         }
     }
 }


### PR DESCRIPTION
I noticed that every time I call the Material#name() method, I get an exception:

`Caused by: java.lang.StringIndexOutOfBoundsException: String index out of range: -2
        at java.lang.String.substring(String.java:1931) ~[?:1.8.0_275] {}
        at org.bukkit.craftbukkit.v1_16_R3.legacy.CraftLegacy.name(CraftLegacyLegacyMixin.java:588) ~[arclight:arclight-1.16.5-1.0.13-ab2ab51] {re:mixin,re:classloading,pl:mixin:APP:mixins.arclight.bukkit.json:CraftLegacyLegacyMixin,pl:mixin:A,re:mixin,re:mixin}`

I think this line was supposed to be substring("LEGACY_".lenght() - 1), but I chose to use replaceAll instead.