### PR TITLE
Fix items stacking in EssentialsX /kit

### DIFF
--- a/arclight-common/src/main/java/io/izzel/arclight/common/mixin/bukkit/MaterialMixin.java
+++ b/arclight-common/src/main/java/io/izzel/arclight/common/mixin/bukkit/MaterialMixin.java
@@ -214,6 +214,13 @@ public abstract class MaterialMixin implements MaterialBridge {
         }
     }
 
+    @Inject(method = "getMaxStackSize", cancellable = true, at = @At("HEAD"))
+    private void arclight$getMaxStackSize(CallbackInfoReturnable<Integer> cir) {
+        if (arclight$spec != null) {
+            cir.setReturnValue(arclight$spec.maxStack);
+        }
+    }
+
     @Override
     public MaterialPropertySpec bridge$getSpec() {
         return arclight$spec;


### PR DESCRIPTION
The maxStack field was already present in MaterialMixin, but it was not being used.