### PR TITLE
尝试修复注册Forge事件监听器时造成的空指针

### DIFF
--- a/arclight-common/src/main/java/io/izzel/arclight/common/mod/util/PluginEventHandler.java
+++ b/arclight-common/src/main/java/io/izzel/arclight/common/mod/util/PluginEventHandler.java
@@ -124,7 +124,7 @@ public class PluginEventHandler extends ASMEventHandler {
         register(eventType, target, real, plugin, bus);
     }
 
-    private static void register(Class<?> eventType, Object target, Method method, Plugin plugin, EventBus bus) {
+    private static synchronized void register(Class<?> eventType, Object target, Method method, Plugin plugin, EventBus bus) {
         try {
             lastedPlugin = plugin;
             ASMEventHandler asm = new PluginEventHandler(plugin, target, method, IGenericEvent.class.isAssignableFrom(eventType));


### PR DESCRIPTION
经尝试，在注册Forge事件监听器时会刷出空指针
原因可能在于PluginEventHandler还未赋值plugin时，父类调用了其createWrapper方法，引用了plugin字段