### PR TITLE
[1.16] Check ServerWorld cast when filling bucket

### DIFF
--- a/arclight-common/src/main/java/io/izzel/arclight/common/mixin/core/item/BucketItemMixin.java
+++ b/arclight-common/src/main/java/io/izzel/arclight/common/mixin/core/item/BucketItemMixin.java
@@ -44,13 +44,15 @@ public abstract class BucketItemMixin {
         BlockPos pos = ((BlockRayTraceResult) result).getPos();
         BlockState state = worldIn.getBlockState(pos);
         Fluid dummyFluid = ((IBucketPickupHandler) state.getBlock()).pickupFluid(DummyGeneratorAccess.INSTANCE, pos, state);
-        PlayerBucketFillEvent event = CraftEventFactory.callPlayerBucketFillEvent((ServerWorld) worldIn, playerIn, pos, pos, ((BlockRayTraceResult) result).getFace(), stack, dummyFluid.getFilledBucket());
-        if (event.isCancelled()) {
-            ((ServerPlayerEntity) playerIn).connection.sendPacket(new SChangeBlockPacket(worldIn, pos));
-            ((ServerPlayerEntityBridge) playerIn).bridge$getBukkitEntity().updateInventory();
-            cir.setReturnValue(new ActionResult<>(ActionResultType.FAIL, stack));
-        } else {
-            arclight$captureItem = event.getItemStack();
+        if (worldIn instanceof ServerWorld) {
+            PlayerBucketFillEvent event = CraftEventFactory.callPlayerBucketFillEvent((ServerWorld) worldIn, playerIn, pos, pos, ((BlockRayTraceResult) result).getFace(), stack, dummyFluid.getFilledBucket());
+            if (event.isCancelled()) {
+                ((ServerPlayerEntity) playerIn).connection.sendPacket(new SChangeBlockPacket(worldIn, pos));
+                ((ServerPlayerEntityBridge) playerIn).bridge$getBukkitEntity().updateInventory();
+                cir.setReturnValue(new ActionResult<>(ActionResultType.FAIL, stack));
+            } else {
+                arclight$captureItem = event.getItemStack();
+            }
         }
     }
 


### PR DESCRIPTION
[crash-2021-09-18_12.35.09-server.txt](https://github.com/IzzelAliz/Arclight/files/7189527/crash-2021-09-18_12.35.09-server.txt)

Related codes:
https://github.com/Creators-of-Create/Create/blob/mc1.16/dev/src/main/java/com/simibubi/create/content/contraptions/components/deployer/DeployerHandler.java#L321

https://github.com/IzzelAliz/Arclight/blob/1.16/arclight-common/src/main/java/io/izzel/arclight/common/mixin/core/item/BucketItemMixin.java#L47

Create uses a special world instance that extends ClientWorld to handle its Mechanical Arm's bucket filling action. Therefore, server will crash when any Mechanical Arm tries to fill its bucket with any fluid. Potential issue with this solution is that Mechanical Arm may be able to act on fluids even when an "Area Protect" plugin is protecting the fluid block. 