### PR TITLE
restored config version code line on ko-kr.conf

### DIFF
--- a/i18n-config/src/main/resources/META-INF/i18n/ko-kr.conf
+++ b/i18n-config/src/main/resources/META-INF/i18n/ko-kr.conf
@@ -93,7 +93,7 @@ comments {
     "이슈 트래커(영문, 중문): https://github.com/IzzelAliz/Arclight/issues"
     ""
     ""
-    "설정의 버전 코드는 수정하지 마십시오."
+    "Config version number, do not edit."
   ]
   locale.comment = "언어/I18n 설정"
   optimization {


### PR DESCRIPTION
I shouldn't have edited the line 96(seems like the version code comes here) but I did so currently making a redo to that line. No other ones are edited so it should work.
Didn't cross-check the other locales' ones, but this line I've edited right now wouldn't work on my previous pull request(created file) if the line is automaticly edited by server client.

Currently working on 1.17, and maybe 1.18 in the same way. Translation quality may vary and maybe improved than this one, but I won't cross-check them since very few checks the debug logs line by line, version by version.