### PR TITLE
OK, ko_kr.conf Updated for 1.18

### DIFF
--- a/i18n-config/src/main/resources/META-INF/i18n/ko_kr.conf
+++ b/i18n-config/src/main/resources/META-INF/i18n/ko_kr.conf
@@ -1,0 +1,121 @@
+logo = [
+  ""
+  ""
+  "   §1    ___ §9     §3     §6___§e  §6   __   /\\"
+  "   §1   /   |§9 ____§3____§6/ §e(_)§6__ / /  / /"
+  "   §1  / /| |§9/ __§3/ __§6/ §e/ /§6 _ / _ \\/__/"
+  "   §1 / ___ §9/ / §3/ /_§6/ §e/ /§6 / / // / /"
+  "   §1/_/  |§9/_/  §3\\__§6/_§e/_/§6\\_ /_//_/ /"
+  "   §1      §9     §3    §6  §e §6/__/     \\/"
+  ""
+  "    §a버전: {}"
+  "    §a빌드 날짜: {}"
+  ""
+]
+java {
+  deprecated = [
+    "오래된 JAVA 버전을 이용하고 있습니다!"
+    "현재: {0}, 권장: {1}"
+    "현재 Java 버전은 향후에 지원되지 않을 것입니다."
+  ]
+}
+
+implementer {
+  not-found = "Class를 찾을 수 없음: {}"
+  error = "오류 발생: {}"
+}
+i18n {
+  current-not-available = "현재 언어 설정 {0}을/를 이용할 수 없습니다."
+  using-language = "언어 {1} 대신 {0}을 사용합니다."
+}
+loading-mapping = "맵핑 로드 중..."
+mixin-load {
+  core = "Arclight core mixin 적용됨"
+  optimization = "Arclight 최적화 mixin 적용됨"
+}
+mod-load = "Arclight 모드 로드됨"
+patcher {
+  loading = "플러그인 패치기 로드 중..."
+  loaded = "{} 패치기 로드 완료"
+  load-error = "패치기 로드 중 오류 발생"
+}
+registry {
+  forge-event = "Arclight 이벤트 적용됨"
+  begin = "버킷에 적용 중..."
+  error = "Forge 적용 중 오류 발생"
+  enchantment = "인챈트({}종) 적용 완료"
+  potion = "신규 물약 효과({}종) 적용 완료"
+  material = "신규 자원(총 {}종: 블록 {}종, 아이템 {}종) 적용 완료"
+  entity-type = "신규 엔티티({}종) 적용 완료"
+  environment = "신규 차원({}종) 적용 완료"
+  villager-profession = "신규 주민 직업({}종) 적용 완료"
+  biome = "신규 바이옴({}종) 적용 완료"
+  meta-type {
+    not-subclass = "{} is not a subclass of {}"
+    error = "{} provided itemMetaType {} is invalid: {}"
+    no-candidate = "{} do not found a valid constructor in prodived itemMetaType {}"
+  }
+  block-state {
+    not-subclass = "{} is not a subclass of {}"
+    error = "{} prodived itemMetaType {} is invalid {}"
+    no-candidate = "{} do not found a valid constructor in provided blockStateClass {}"
+  }
+  entity {
+    not-subclass = "{} is not a subclass of {}"
+    error = "{} prodived entityClass {} is invalid: {}"
+  }
+}
+dfu-disable {
+  legacy-plugin = "optimization.disable-data-fixer가 활성화되어 있으면 구형 플러그인이 동작하지 않습니다."
+  map-convert = "optimization.disable-data-fixer가 활성화되어 있으면 월드의 업그레이드가 불가합니다."
+}
+error-symlink = "파일 시스템이 symbolic link를 지원하지 않습니다."
+
+comments {
+  _v.comment = [
+    "레포지트리(영문): https://github.com/IzzelAliz/Arclight"
+    "이슈 트래커(영문, 중문): https://github.com/IzzelAliz/Arclight/issues"
+    ""
+    ""
+    "Config version number, do not edit."
+  ]
+  locale.comment = "언어/I18n 설정"
+  optimization {
+    comment = "최적화 관련 설정"
+    disable-data-fixer.comment = [
+      "레벨 데이터 업그레이드에 이용되는 DataFixerUpper 시스템을 비활성화합니다."
+      "서버 시작과 월드 로드 속도를 올리고, 메모리 사용량을 80~200MB까지 줄일 수 있습니다."
+      "Arclight 및 개발자는 데이터 손실을 책임지지 않습니다."
+      "상용 서버에서는 사용하지 마십시오!"
+    ]
+    goal-selector-update-interval.comment = [
+      "목표 선택기가 업데이트되는 시간(틱 단위)을 설정합니다."
+      "높은 값은 더 적은 리소스를 소모합니다."
+      "대신 몹의 목표 변경이 덜 자주 일어나게 됩니다."
+    ]
+  }
+  async-catcher.comment = [
+    "Async Catcher 관련 설정"
+    "네 개의 모드가 있으며, 블록이 반드시 필요합니다."
+    "NONE - 아무 것도 하지 않음"
+    "DISPATCH - 주 스레드에 올리지 않고 백그라운드에서 실행"
+    "BLOCK - 주 스레드에 올리고 결과를 대기"
+    "EXCEPTION - 오류를 발생"
+  ]
+  async-catcher.dump.comment = "스택 추적 덤프 정보는 debug.log에 있습니다."
+  compatibility {
+    symlink-world.comment = [
+      "버킷 포맷에 맞도록 모드 차원 폴더에 대한 Symbolic Link를 생성합니다."
+      "활성화하면 플러그인과의 호환성을 향상시킬 수 있습니다."
+      "이 설정을 수정하면 모드의 월드 명칭이 바뀌어 월드 명칭에 의존하는 플러그인의"
+      "  데이터 손실이 발생할 수 있습니다."
+      "https://github.com/IzzelAliz/Arclight/wiki/World-Symlink (영문)에서 자세한"
+      "  내용을 확인하세요."
+    ]
+    extra-logic-worlds.comment = [
+      "별도 세계 작동 로직"
+      "제대로 작동하지 않는 모드가 있다면, 로그 파일에서 [EXT_LOGIC]와 관련된 클래스 명을"
+      "  찾아 여기에 추가해 주세요."
+    ]
+  }
+}


### PR DESCRIPTION
Copied 1.17's ko-kr.conf I've made into 1.18's since most of the lines are identical. However, while double-checking en-us.conf, the new lines have added so just added and updated the translations.

No removed lines... Right?


Uhm, there's 4 backup repos on my fork. Created in 6 hours. What a shame.