### PR TITLE
Fix applyToItem IllegalArgumentException

### DIFF
--- a/arclight-common/src/main/java/io/izzel/arclight/common/mixin/bukkit/CraftMetaSkullMixin.java
+++ b/arclight-common/src/main/java/io/izzel/arclight/common/mixin/bukkit/CraftMetaSkullMixin.java
@@ -1,0 +1,22 @@
+package io.izzel.arclight.common.mixin.bukkit;
+
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.nbt.Tag;
+import org.bukkit.craftbukkit.v.inventory.CraftMetaItem;
+import org.bukkit.craftbukkit.v.inventory.CraftMetaSkull;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+@Mixin(CraftMetaSkull.class)
+public class CraftMetaSkullMixin extends CraftMetaItem {
+
+    public CraftMetaSkullMixin(CraftMetaItem meta) {
+        super(meta);
+    }
+
+    @Redirect(method = "applyToItem", at = @At(value = "INVOKE", target = "Lnet/minecraft/nbt/CompoundTag;put(Ljava/lang/String;Lnet/minecraft/nbt/Tag;)Lnet/minecraft/nbt/Tag;"))
+    private Tag arclight$fixNullValue(CompoundTag instance, String key, Tag value) {
+        return value == null ? null : instance.put(key, value);
+    }
+}

--- a/arclight-common/src/main/resources/mixins.arclight.bukkit.json
+++ b/arclight-common/src/main/resources/mixins.arclight.bukkit.json
@@ -11,6 +11,7 @@
   },
   "compatibilityLevel": "JAVA_11",
   "mixins": [
+    "CraftMetaSkullMixin",
     "BukkitCommandWrapperMixin",
     "ColouredConsoleSenderMixin",
     "CraftAbstractVillagerMixin",


### PR DESCRIPTION
Forge patches `CompoundTag#put` to throw an `IllegalArgumentException` if a null value is passed in. Some bukkit plugins don't expect this as it's added by Forge so they pass null values in which causes crashes.