### PR TITLE
Updated Forge version to 40.1.0 with some fixes for issues found.

### DIFF
--- a/arclight-common/src/main/java/io/izzel/arclight/common/bridge/core/world/chunk/LevelChunkSectionBridge.java
+++ b/arclight-common/src/main/java/io/izzel/arclight/common/bridge/core/world/chunk/LevelChunkSectionBridge.java
@@ -1,8 +1,9 @@
 package io.izzel.arclight.common.bridge.core.world.chunk;
 
+import net.minecraft.core.Holder;
 import net.minecraft.world.level.biome.Biome;
 
 public interface LevelChunkSectionBridge {
 
-    void bridge$setBiome(int x, int y, int z, Biome biome);
+    void bridge$setBiome(int x, int y, int z, Holder<Biome> biome);
 }

--- a/arclight-common/src/main/java/io/izzel/arclight/common/mixin/core/world/food/FoodDataMixin.java
+++ b/arclight-common/src/main/java/io/izzel/arclight/common/mixin/core/world/food/FoodDataMixin.java
@@ -6,6 +6,7 @@ import io.izzel.arclight.common.bridge.core.entity.player.ServerPlayerEntityBrid
 import io.izzel.arclight.common.bridge.core.util.FoodStatsBridge;
 import net.minecraft.network.protocol.game.ClientboundSetHealthPacket;
 import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.food.FoodData;
 import net.minecraft.world.food.FoodProperties;
@@ -21,6 +22,8 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.Redirect;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import javax.annotation.Nullable;
 
 @Mixin(FoodData.class)
 public abstract class FoodDataMixin implements FoodStatsBridge {
@@ -46,13 +49,13 @@ public abstract class FoodDataMixin implements FoodStatsBridge {
         this.entityhuman = playerEntity;
     }
 
-    @Redirect(method = "eat(Lnet/minecraft/world/item/Item;Lnet/minecraft/world/item/ItemStack;)V", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/food/FoodData;eat(IF)V"))
-    public void arclight$foodLevelChange(FoodData foodStats, int foodLevelIn, float foodSaturationModifier, Item maybeFood, ItemStack stack) {
+    @Redirect(method = "eat(Lnet/minecraft/world/item/Item;Lnet/minecraft/world/item/ItemStack;Lnet/minecraft/world/entity/LivingEntity;)V", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/food/FoodData;eat(IF)V"))
+    public void arclight$foodLevelChange(FoodData foodStats, int foodLevelIn, float foodSaturationModifier, Item maybeFood, ItemStack stack, @Nullable LivingEntity entity) {
         if (entityhuman == null) {
             foodStats.eat(foodLevelIn, foodSaturationModifier);
             return;
         }
-        FoodProperties food = maybeFood.getFoodProperties();
+        FoodProperties food = maybeFood.getFoodProperties(stack, entity);
         int oldFoodLevel = this.foodLevel;
         FoodLevelChangeEvent event = CraftEventFactory.callFoodLevelChangeEvent(entityhuman, food.getNutrition() + oldFoodLevel, stack);
         if (!event.isCancelled()) {

--- a/arclight-common/src/main/java/io/izzel/arclight/common/mixin/core/world/level/chunk/ChunkAccessMixin.java
+++ b/arclight-common/src/main/java/io/izzel/arclight/common/mixin/core/world/level/chunk/ChunkAccessMixin.java
@@ -75,10 +75,6 @@ public abstract class ChunkAccessMixin implements BlockGetter, BiomeManager.Nois
     }
 
     public void setBiome(int i, int j, int k, Holder<Biome> biome) {
-        setBiome(i, j, k, biome.value());
-    }
-
-    public void setBiome(int i, int j, int k, Biome biome) {
         try {
             int l = QuartPos.fromBlock(this.getMinBuildHeight());
             int i1 = l + QuartPos.fromBlock(this.getHeight()) - 1;

--- a/arclight-common/src/main/java/io/izzel/arclight/common/mixin/core/world/level/chunk/ChunkAccessMixin.java
+++ b/arclight-common/src/main/java/io/izzel/arclight/common/mixin/core/world/level/chunk/ChunkAccessMixin.java
@@ -6,6 +6,7 @@ import net.minecraft.CrashReport;
 import net.minecraft.CrashReportCategory;
 import net.minecraft.ReportedException;
 import net.minecraft.core.BlockPos;
+import net.minecraft.core.Holder;
 import net.minecraft.core.QuartPos;
 import net.minecraft.core.Registry;
 import net.minecraft.nbt.CompoundTag;
@@ -71,6 +72,10 @@ public abstract class ChunkAccessMixin implements BlockGetter, BiomeManager.Nois
     @Override
     public PersistentDataContainer bridge$getPersistentDataContainer() {
         return this.persistentDataContainer;
+    }
+
+    public void setBiome(int i, int j, int k, Holder<Biome> biome) {
+        setBiome(i, j, k, biome.value());
     }
 
     public void setBiome(int i, int j, int k, Biome biome) {

--- a/arclight-common/src/main/java/io/izzel/arclight/common/mixin/core/world/level/chunk/LevelChunkSectionMixin.java
+++ b/arclight-common/src/main/java/io/izzel/arclight/common/mixin/core/world/level/chunk/LevelChunkSectionMixin.java
@@ -16,11 +16,11 @@ import org.spongepowered.asm.mixin.Shadow;
 
 @Mixin(LevelChunkSection.class)
 public class LevelChunkSectionMixin implements LevelChunkSectionBridge {
-    
+    final Registry<Biome> registry = ((CraftServer)(Bukkit.getServer())).getServer().registryAccess().registryOrThrow(Registry.BIOME_REGISTRY);
+
     @Shadow @Final private PalettedContainer<Holder<Biome>> biomes;
 
     public void setBiome(int i, int j, int k, net.minecraft.world.level.biome.Biome biome) {
-        Registry<Biome> registry = ((CraftServer)(Bukkit.getServer())).getServer().registryAccess().registryOrThrow(Registry.BIOME_REGISTRY);
         this.biomes.set(i, j, k, CraftBlock.biomeToBiomeBase(registry, org.bukkit.block.Biome.valueOf(ResourceLocationUtil.standardize(biome.getRegistryName()))));
     }
 

--- a/arclight-common/src/main/java/io/izzel/arclight/common/mixin/core/world/level/chunk/LevelChunkSectionMixin.java
+++ b/arclight-common/src/main/java/io/izzel/arclight/common/mixin/core/world/level/chunk/LevelChunkSectionMixin.java
@@ -1,19 +1,30 @@
 package io.izzel.arclight.common.mixin.core.world.level.chunk;
 
 import io.izzel.arclight.common.bridge.core.world.chunk.LevelChunkSectionBridge;
+import io.izzel.arclight.common.mod.util.ResourceLocationUtil;
+import net.minecraft.core.Holder;
 import net.minecraft.world.level.biome.Biome;
 import net.minecraft.world.level.chunk.LevelChunkSection;
 import net.minecraft.world.level.chunk.PalettedContainer;
+import org.bukkit.Bukkit;
+import net.minecraft.core.Registry;
+import org.bukkit.craftbukkit.v.CraftServer;
+import org.bukkit.craftbukkit.v.block.CraftBlock;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 
 @Mixin(LevelChunkSection.class)
 public class LevelChunkSectionMixin implements LevelChunkSectionBridge {
+    
+    @Shadow @Final private PalettedContainer<Holder<Biome>> biomes;
 
-    @Shadow @Final private PalettedContainer<Biome> biomes;
+    public void setBiome(int i, int j, int k, net.minecraft.world.level.biome.Biome biome) {
+        Registry<Biome> registry = ((CraftServer)(Bukkit.getServer())).getServer().registryAccess().registryOrThrow(Registry.BIOME_REGISTRY);
+        this.biomes.set(i, j, k, CraftBlock.biomeToBiomeBase(registry, org.bukkit.block.Biome.valueOf(ResourceLocationUtil.standardize(biome.getRegistryName()))));
+    }
 
-    public void setBiome(int i, int j, int k, Biome biome) {
+    public void setBiome(int i, int j, int k, Holder<net.minecraft.world.level.biome.Biome> biome) {
         this.biomes.set(i, j, k, biome);
     }
 

--- a/arclight-common/src/main/java/io/izzel/arclight/common/mixin/core/world/level/chunk/LevelChunkSectionMixin.java
+++ b/arclight-common/src/main/java/io/izzel/arclight/common/mixin/core/world/level/chunk/LevelChunkSectionMixin.java
@@ -16,20 +16,15 @@ import org.spongepowered.asm.mixin.Shadow;
 
 @Mixin(LevelChunkSection.class)
 public class LevelChunkSectionMixin implements LevelChunkSectionBridge {
-    final Registry<Biome> registry = ((CraftServer)(Bukkit.getServer())).getServer().registryAccess().registryOrThrow(Registry.BIOME_REGISTRY);
 
     @Shadow @Final private PalettedContainer<Holder<Biome>> biomes;
-
-    public void setBiome(int i, int j, int k, net.minecraft.world.level.biome.Biome biome) {
-        this.biomes.set(i, j, k, CraftBlock.biomeToBiomeBase(registry, org.bukkit.block.Biome.valueOf(ResourceLocationUtil.standardize(biome.getRegistryName()))));
-    }
 
     public void setBiome(int i, int j, int k, Holder<net.minecraft.world.level.biome.Biome> biome) {
         this.biomes.set(i, j, k, biome);
     }
 
     @Override
-    public void bridge$setBiome(int x, int y, int z, Biome biome) {
+    public void bridge$setBiome(int x, int y, int z, Holder<Biome> biome) {
         this.setBiome(x, y, z, biome);
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ allprojects {
     ext {
         agpVersion = '1.22'
         minecraftVersion = '1.18.2'
-        forgeVersion = '40.0.36'
+        forgeVersion = '40.1.0'
         apiVersion = '1.2.6'
         toolsVersion = '1.3.+'
         mixinVersion = '0.8.5'


### PR DESCRIPTION
## Commit 8a9361dc456932751f4b2ce5d5396dadf24644b3
- Updated Forge version from 40.0.36 to 40.1.0

## Commit be1318dd56bb8358a89fdbc11375548c2edd9a42
- Change the injection point of FoodDataMixin#foodLevelChange from eat(Item,ItemStack) to eat(Item,ItemStack,LivingEntity). Because the old method has been marked as obsolete.
- Modify getFoodProperties() to getFoodProperties(ItemStack, LivingEntity). Because the old method has been marked as obsolete.