### PR TITLE
feat(chunks): remove unnecessary shuffling and allocation on chunk ticking

### DIFF
--- a/arclight-forge/src/main/java/io/izzel/arclight/impl/mixin/optimization/general/chunkticking/ServerChunkProviderMixin_Optimize.java
+++ b/arclight-forge/src/main/java/io/izzel/arclight/impl/mixin/optimization/general/chunkticking/ServerChunkProviderMixin_Optimize.java
@@ -1,0 +1,42 @@
+package io.izzel.arclight.impl.mixin.optimization.general.chunkticking;
+
+import io.izzel.arclight.common.bridge.world.server.ChunkManagerBridge;
+import jdk.internal.org.objectweb.asm.Opcodes;
+import net.minecraft.world.server.ChunkManager;
+import net.minecraft.world.server.ServerChunkProvider;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.ModifyVariable;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Consumer;
+
+@Mixin(ServerChunkProvider.class)
+public class ServerChunkProviderMixin_Optimize {
+
+    // @formatter:off
+    @Shadow @Final public ChunkManager chunkManager;
+    // @formatter:on
+
+    private static final ArrayList<?> EMPTY = new ArrayList<>(0);
+
+    @Redirect(method = "Lnet/minecraft/world/server/ServerChunkProvider;tickChunks()V",
+    at = @At(value = "INVOKE", target = "Lcom/google/common/collect/Lists;newArrayList(Ljava/lang/Iterable;)Ljava/util/ArrayList;"))
+    public ArrayList<?> handle(Iterable<?> elements) {
+        return EMPTY;
+    }
+
+    @Redirect(method = "Lnet/minecraft/world/server/ServerChunkProvider;tickChunks()V",
+            at = @At(value = "INVOKE", target = "Ljava/util/Collections;shuffle(Ljava/util/List;)V"))
+    public void handle(List<?> objects) {}
+
+    @Redirect(method = "Lnet/minecraft/world/server/ServerChunkProvider;tickChunks()V",
+    at = @At(value = "INVOKE", target = "Ljava/util/List;forEach(Ljava/util/function/Consumer;)V"))
+    public void forEach(List instance, Consumer consumer) {
+        ((ChunkManagerBridge) this.chunkManager).bridge$getLoadedChunksIterable().forEach(consumer);
+    }
+}

--- a/arclight-forge/src/main/java/io/izzel/arclight/impl/mixin/optimization/general/chunkticking/ServerChunkProviderMixin_Optimize.java
+++ b/arclight-forge/src/main/java/io/izzel/arclight/impl/mixin/optimization/general/chunkticking/ServerChunkProviderMixin_Optimize.java
@@ -1,7 +1,6 @@
 package io.izzel.arclight.impl.mixin.optimization.general.chunkticking;
 
 import io.izzel.arclight.common.bridge.world.server.ChunkManagerBridge;
-import jdk.internal.org.objectweb.asm.Opcodes;
 import net.minecraft.world.server.ChunkManager;
 import net.minecraft.world.server.ServerChunkProvider;
 import org.spongepowered.asm.mixin.Final;
@@ -26,17 +25,17 @@ public class ServerChunkProviderMixin_Optimize {
 
     @Redirect(method = "Lnet/minecraft/world/server/ServerChunkProvider;tickChunks()V",
     at = @At(value = "INVOKE", target = "Lcom/google/common/collect/Lists;newArrayList(Ljava/lang/Iterable;)Ljava/util/ArrayList;"))
-    public ArrayList<?> handle(Iterable<?> elements) {
+    public ArrayList<?> arclight$removeNewList(Iterable<?> elements) {
         return EMPTY;
     }
 
     @Redirect(method = "Lnet/minecraft/world/server/ServerChunkProvider;tickChunks()V",
             at = @At(value = "INVOKE", target = "Ljava/util/Collections;shuffle(Ljava/util/List;)V"))
-    public void handle(List<?> objects) {}
+    public void arclight$removeShuffle(List<?> objects) {}
 
     @Redirect(method = "Lnet/minecraft/world/server/ServerChunkProvider;tickChunks()V",
     at = @At(value = "INVOKE", target = "Ljava/util/List;forEach(Ljava/util/function/Consumer;)V"))
-    public void forEach(List instance, Consumer consumer) {
+    public void arclight$redirectChunkForEach(List instance, Consumer consumer) {
         ((ChunkManagerBridge) this.chunkManager).bridge$getLoadedChunksIterable().forEach(consumer);
     }
 }

--- a/arclight-forge/src/main/resources/mixins.arclight.impl.forge.optimization.json
+++ b/arclight-forge/src/main/resources/mixins.arclight.impl.forge.optimization.json
@@ -19,6 +19,7 @@
     "activationrange.entity.VillagerEntityMixin_ActivationRange",
     "realtime.ItemEntityMixin_Realtime",
     "realtime.PlayerInteractionManagerMixin_Realtime",
-    "trackingrange.ChunkManagerMixin_TrackingRange"
+    "trackingrange.ChunkManagerMixin_TrackingRange",
+    "chunkticking.ServerChunkProviderMixin_Optimize"
   ]
 }


### PR DESCRIPTION
https://spark.lucko.me/25j5H6DaMN - Some amount of performance is lost on allocating, and shuffling, the chunk list every time the server ticks the chunks. It's not the majority of the performance loss from this Spark but it is some of it. 

https://github.com/PaperMC/Paper/blob/ver/1.16.5/Spigot-Server-Patches/0004-MC-Utils.patch#L3261