### PR TITLE
Fix ChestBlockDoubleInventoryHacks

### DIFF
--- a/arclight-common/src/main/java/io/izzel/arclight/common/mod/server/block/ChestBlockDoubleInventoryHacks.java
+++ b/arclight-common/src/main/java/io/izzel/arclight/common/mod/server/block/ChestBlockDoubleInventoryHacks.java
@@ -12,7 +12,7 @@ public class ChestBlockDoubleInventoryHacks {
 
     static {
         try {
-            cl = Class.forName("net/minecraft/world/level/block/ChestBlock$2$1");
+            cl = Class.forName("net.minecraft.world.level.block.ChestBlock$2$1");
             Field field = cl.getDeclaredField("inventorylargechest");
             offset = Unsafe.objectFieldOffset(field);
         } catch (Exception e) {


### PR DESCRIPTION
尝试修复引用该类时出现ClassNotFoundException的问题。该类只在极其罕见的情况下会被引用，然后导致服务器崩溃，但我未能测试出导致该问题的模组或插件，改写成新的locator后似乎没有再出现过该问题。
不是非常清楚这个locator是否是有意这么写，如果我理解有误请见谅，并关闭该pr : )。