### PR TITLE
Allow modifying repair cost cap by ModifyConstant (#663)

### DIFF
--- a/arclight-common/src/main/java/io/izzel/arclight/common/mixin/core/world/inventory/RepairContainerMixin.java
+++ b/arclight-common/src/main/java/io/izzel/arclight/common/mixin/core/world/inventory/RepairContainerMixin.java
@@ -34,7 +34,11 @@ public abstract class RepairContainerMixin extends ItemCombinerMixin {
     @Shadow public static int calculateIncreasedRepairCost(int oldRepairCost) { return 0; }
     // @formatter:on
 
+    public int cancelThisBySettingCostToMaximum = 40;
+    public int maximumRenameCostThreshold = 40;
+    public int maximumAllowedRenameCost = 39;
     public int maximumRepairCost = 40;
+
     private CraftInventoryView bukkitEntity;
 
     /**
@@ -43,6 +47,12 @@ public abstract class RepairContainerMixin extends ItemCombinerMixin {
      */
     @Overwrite
     public void createResult() {
+        // define constants for ModifyConstant mixins to work
+        cancelThisBySettingCostToMaximum = 40;
+        maximumRenameCostThreshold = 40;
+        maximumAllowedRenameCost = 39;
+        maximumRepairCost = 40;
+
         ItemStack itemstack = this.inputSlots.getItem(0);
         this.cost.set(1);
         int i = 0;
@@ -157,7 +167,7 @@ public abstract class RepairContainerMixin extends ItemCombinerMixin {
 
                                 i += k3 * j2;
                                 if (itemstack.getCount() > 1) {
-                                    i = 40;
+                                    i = cancelThisBySettingCostToMaximum;
                                 }
                             }
                         }
@@ -190,8 +200,8 @@ public abstract class RepairContainerMixin extends ItemCombinerMixin {
                 itemstack1 = ItemStack.EMPTY;
             }
 
-            if (k == i && k > 0 && this.cost.get() >= maximumRepairCost) {
-                this.cost.set(maximumRepairCost - 1);
+            if (k == i && k > 0 && this.cost.get() >= maximumRenameCostThreshold) {
+                this.cost.set(maximumAllowedRenameCost);
             }
 
             if (this.cost.get() >= maximumRepairCost && !this.player.getAbilities().instabuild) {


### PR DESCRIPTION
典型的修改维修经验消耗上限的方法除了inject自己的逻辑以外，还有一个方法是直接修改香草实现中硬编码的经验消耗上限。
这个pr将香草实现中放在函数里的四个常量重新加进了函数，这可以修复之前实现中类似如下的mixin失效的问题：
比如：
神化（Apotheosis）的[AnvilMenuMixin.java](https://github.com/Shadows-of-Fire/Apotheosis/blob/5dd04d6f1e209a52a452382e81e8be39ff930e22/src/main/java/shadows/apotheosis/mixin/AnvilMenuMixin.java#L9-L17)
```
@Mixin(AnvilMenu.class)
public class AnvilMenuMixin {
	@ModifyConstant(method = "createResult()V", constant = @Constant(intValue = 40))
	public int apoth_removeLevelCap(int old) {
		return Integer.MAX_VALUE;
	}
}
```
铁砧修复Forge版（AnvilFixForge）会更准确地指定为是第三个值为40的常量，也就是最后一个：[AnvilMenuMixin.java](https://github.com/TrueGkoliver/AnvilFixForge/blob/78b763d8f4cbc33a6cee222d72c8983791bdc408/src/main/java/com/gkoliver/anvilfix/mixin/AnvilMenuMixin.java#L13-L18)
```
    @ModifyConstant(method = "createResult()V", constant = @Constant(intValue = 40, ordinal = 2))
    private int modifyInt(int input) {
        return AnvilFixConfig.getLevelLimit();
    }
```

已知缺陷：
会导致额外16个字节的内存占用