### PR TITLE
Fix ArclightCaptures reset before event being handled (#674)

### DIFF
--- a/arclight-common/src/main/java/io/izzel/arclight/common/mixin/core/server/management/ServerPlayerGameModeMixin.java
+++ b/arclight-common/src/main/java/io/izzel/arclight/common/mixin/core/server/management/ServerPlayerGameModeMixin.java
@@ -34,6 +34,7 @@ import net.minecraft.world.phys.BlockHitResult;
 import net.minecraftforge.common.ForgeHooks;
 import org.bukkit.Bukkit;
 import org.bukkit.GameMode;
+import org.bukkit.block.Block;
 import org.bukkit.craftbukkit.v.block.CraftBlock;
 import org.bukkit.craftbukkit.v.event.CraftEventFactory;
 import org.bukkit.event.Event;
@@ -219,11 +220,35 @@ public abstract class ServerPlayerGameModeMixin implements PlayerInteractionMana
         }
     }
 
+    @Inject(method = "destroyBlock", at = @At(value = "INVOKE", target = "Lnet/minecraftforge/common/ForgeHooks;onBlockBreakEvent(Lnet/minecraft/world/level/Level;Lnet/minecraft/world/level/GameType;Lnet/minecraft/server/level/ServerPlayer;Lnet/minecraft/core/BlockPos;)I"))
+    public void arclight$beforePrimaryEventFired(BlockPos pos, CallbackInfoReturnable<Boolean> cir) {
+        ArclightCaptures.captureNextBlockBreakEventAsPrimaryEvent();
+    }
+
+    @Inject(method = "destroyBlock", at = @At(value = "INVOKE_ASSIGN", target = "Lnet/minecraftforge/common/ForgeHooks;onBlockBreakEvent(Lnet/minecraft/world/level/Level;Lnet/minecraft/world/level/GameType;Lnet/minecraft/server/level/ServerPlayer;Lnet/minecraft/core/BlockPos;)I"))
+    public void arclight$handleSecondaryBlockBreakEvents(BlockPos pos, CallbackInfoReturnable<Boolean> cir) {
+        ArclightCaptures.BlockBreakEventContext breakEventContext = ArclightCaptures.resetSecondaryBlockBreakPlayer();
+        while (breakEventContext != null) {
+            Block block = breakEventContext.getEvent().getBlock();
+            handleBlockBreak(breakEventContext, new BlockPos(block.getX(), block.getY(), block.getZ()));
+            breakEventContext = ArclightCaptures.resetSecondaryBlockBreakPlayer();
+        }
+    }
+
     @Inject(method = "destroyBlock", at = @At("RETURN"))
     public void arclight$resetBlockBreak(BlockPos pos, CallbackInfoReturnable<Boolean> cir) {
-        List<ItemEntity> blockDrops = ArclightCaptures.getBlockDrops();
-        org.bukkit.block.BlockState state = ArclightCaptures.getBlockBreakPlayerState();
-        BlockBreakEvent breakEvent = ArclightCaptures.resetBlockBreakPlayer();
+        ArclightCaptures.BlockBreakEventContext breakEventContext = ArclightCaptures.resetBlockBreakPlayer();
+
+        if (breakEventContext != null) {
+            handleBlockBreak(breakEventContext, pos);
+        }
+    }
+
+    private void handleBlockBreak(ArclightCaptures.BlockBreakEventContext breakEventContext, BlockPos pos) {
+        BlockBreakEvent breakEvent = breakEventContext.getEvent();
+        List<ItemEntity> blockDrops = breakEventContext.getBlockDrops();
+        org.bukkit.block.BlockState state = breakEventContext.getBlockBreakPlayerState();
+
         if (blockDrops != null && (breakEvent == null || breakEvent.isDropItems())) {
             CraftBlock craftBlock = CraftBlock.at(this.level, pos);
             CraftEventFactory.handleBlockDropItemEvent(craftBlock, state, this.player, blockDrops);

--- a/arclight-common/src/main/java/io/izzel/arclight/common/mixin/core/server/management/ServerPlayerGameModeMixin.java
+++ b/arclight-common/src/main/java/io/izzel/arclight/common/mixin/core/server/management/ServerPlayerGameModeMixin.java
@@ -49,6 +49,7 @@ import org.spongepowered.asm.mixin.Overwrite;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 import java.util.List;
@@ -227,24 +228,31 @@ public abstract class ServerPlayerGameModeMixin implements PlayerInteractionMana
 
     @Inject(method = "destroyBlock", at = @At(value = "INVOKE_ASSIGN", target = "Lnet/minecraftforge/common/ForgeHooks;onBlockBreakEvent(Lnet/minecraft/world/level/Level;Lnet/minecraft/world/level/GameType;Lnet/minecraft/server/level/ServerPlayer;Lnet/minecraft/core/BlockPos;)I"))
     public void arclight$handleSecondaryBlockBreakEvents(BlockPos pos, CallbackInfoReturnable<Boolean> cir) {
-        ArclightCaptures.BlockBreakEventContext breakEventContext = ArclightCaptures.resetSecondaryBlockBreakPlayer();
+        ArclightCaptures.BlockBreakEventContext breakEventContext = ArclightCaptures.popSecondaryBlockBreakEvent();
         while (breakEventContext != null) {
             Block block = breakEventContext.getEvent().getBlock();
-            handleBlockBreak(breakEventContext, new BlockPos(block.getX(), block.getY(), block.getZ()));
-            breakEventContext = ArclightCaptures.resetSecondaryBlockBreakPlayer();
+            handleBlockDrop(breakEventContext, new BlockPos(block.getX(), block.getY(), block.getZ()));
+            breakEventContext = ArclightCaptures.popSecondaryBlockBreakEvent();
         }
     }
 
     @Inject(method = "destroyBlock", at = @At("RETURN"))
     public void arclight$resetBlockBreak(BlockPos pos, CallbackInfoReturnable<Boolean> cir) {
-        ArclightCaptures.BlockBreakEventContext breakEventContext = ArclightCaptures.resetBlockBreakPlayer();
+        ArclightCaptures.BlockBreakEventContext breakEventContext = ArclightCaptures.popPrimaryBlockBreakEvent();
 
         if (breakEventContext != null) {
-            handleBlockBreak(breakEventContext, pos);
+            handleBlockDrop(breakEventContext, pos);
         }
     }
 
-    private void handleBlockBreak(ArclightCaptures.BlockBreakEventContext breakEventContext, BlockPos pos) {
+    @Inject(method = {"tick", "destroyAndAck"}, at = @At(value = "INVOKE", target = "Lnet/minecraft/server/level/ServerPlayerGameMode;destroyBlock(Lnet/minecraft/core/BlockPos;)Z"))
+    public void arclight$clearCaptures(CallbackInfo ci) {
+        // clear the event stack in case that interrupted events are left here unhandled
+        // it should be a new event capture session each time destroyBlock is called from these two contexts
+        ArclightCaptures.clearBlockBreakEventContexts();
+    }
+
+    private void handleBlockDrop(ArclightCaptures.BlockBreakEventContext breakEventContext, BlockPos pos) {
         BlockBreakEvent breakEvent = breakEventContext.getEvent();
         List<ItemEntity> blockDrops = breakEventContext.getBlockDrops();
         org.bukkit.block.BlockState state = breakEventContext.getBlockBreakPlayerState();

--- a/arclight-common/src/main/java/io/izzel/arclight/common/mixin/core/world/level/block/BlockMixin.java
+++ b/arclight-common/src/main/java/io/izzel/arclight/common/mixin/core/world/level/block/BlockMixin.java
@@ -76,7 +76,7 @@ public abstract class BlockMixin extends BlockBehaviourMixin implements BlockBri
 
     @Inject(method = "playerDestroy", at = @At("RETURN"))
     private void arclight$handleBlockDrops(Level worldIn, Player player, BlockPos pos, BlockState blockState, BlockEntity te, ItemStack stack, CallbackInfo ci) {
-        ArclightCaptures.BlockBreakEventContext breakEventContext = ArclightCaptures.resetBlockBreakPlayer();
+        ArclightCaptures.BlockBreakEventContext breakEventContext = ArclightCaptures.popPrimaryBlockBreakEvent();
 
         if (breakEventContext != null) {
             BlockBreakEvent breakEvent = breakEventContext.getEvent();

--- a/arclight-common/src/main/java/io/izzel/arclight/common/mixin/core/world/level/block/BlockMixin.java
+++ b/arclight-common/src/main/java/io/izzel/arclight/common/mixin/core/world/level/block/BlockMixin.java
@@ -76,13 +76,18 @@ public abstract class BlockMixin extends BlockBehaviourMixin implements BlockBri
 
     @Inject(method = "playerDestroy", at = @At("RETURN"))
     private void arclight$handleBlockDrops(Level worldIn, Player player, BlockPos pos, BlockState blockState, BlockEntity te, ItemStack stack, CallbackInfo ci) {
-        List<ItemEntity> blockDrops = ArclightCaptures.getBlockDrops();
-        org.bukkit.block.BlockState state = ArclightCaptures.getBlockBreakPlayerState();
-        BlockBreakEvent breakEvent = ArclightCaptures.resetBlockBreakPlayer();
-        if (player instanceof ServerPlayer && blockDrops != null && (breakEvent == null || breakEvent.isDropItems())
-            && DistValidate.isValid(worldIn)) {
-            CraftBlock craftBlock = CraftBlock.at(((CraftWorld) state.getWorld()).getHandle(), pos);
-            CraftEventFactory.handleBlockDropItemEvent(craftBlock, state, ((ServerPlayer) player), blockDrops);
+        ArclightCaptures.BlockBreakEventContext breakEventContext = ArclightCaptures.resetBlockBreakPlayer();
+
+        if (breakEventContext != null) {
+            BlockBreakEvent breakEvent = breakEventContext.getEvent();
+            List<ItemEntity> blockDrops = breakEventContext.getBlockDrops();
+            org.bukkit.block.BlockState state = breakEventContext.getBlockBreakPlayerState();
+
+            if (player instanceof ServerPlayer && blockDrops != null && (breakEvent == null || breakEvent.isDropItems())
+                    && DistValidate.isValid(worldIn)) {
+                CraftBlock craftBlock = CraftBlock.at(((CraftWorld) state.getWorld()).getHandle(), pos);
+                CraftEventFactory.handleBlockDropItemEvent(craftBlock, state, ((ServerPlayer) player), blockDrops);
+            }
         }
     }
 }

--- a/arclight-common/src/main/java/io/izzel/arclight/common/mod/util/ArclightCaptures.java
+++ b/arclight-common/src/main/java/io/izzel/arclight/common/mod/util/ArclightCaptures.java
@@ -39,9 +39,14 @@ public class ArclightCaptures {
     private static BlockState blockBreakPlayerState;
 
     public static void captureBlockBreakPlayer(BlockBreakEvent event) {
-        blockBreakEvent = event;
-        blockDrops = new ArrayList<>();
-        blockBreakPlayerState = event.getBlock().getState();
+        if (blockBreakEvent == null) {
+            // Force event context to be captured only when no event is being handled.
+            // Otherwise, it should be fired by handlers of current event as the event system is single threaded,
+            // which should not change the event context.
+            blockBreakEvent = event;
+            blockDrops = new ArrayList<>();
+            blockBreakPlayerState = event.getBlock().getState();
+        }
     }
 
     public static BlockBreakEvent getBlockBreakPlayer() {


### PR DESCRIPTION
连锁挖矿模组[Vein Mining](https://www.curseforge.com/minecraft/mc-mods/vein-mining/files/3903527)通过监听BlockBreakEvent事件并在handler中用自己实现的destroyBlock([VeinMiningLogic.java](https://github.com/TheIllusiveC4/VeinMining/blob/439cd78685e2b2ac22d869277a3c2d08689c7b21/forge/src/main/java/top/theillusivec4/veinmining/veinmining/logic/VeinMiningLogic.java#L158-L209))来破坏相连的方块，借此实现兼容其他挖掘方块的事件。

这个pr添加了特别的检查来防止ArclightCaptures捕获的事件上下文被中途触发的后续事件重置。