### PR TITLE
Fix PartEntity not recognized by updating PlayerMixin#attack (#662)

### DIFF
--- a/arclight-common/src/main/java/io/izzel/arclight/common/mixin/core/world/entity/player/PlayerMixin.java
+++ b/arclight-common/src/main/java/io/izzel/arclight/common/mixin/core/world/entity/player/PlayerMixin.java
@@ -54,6 +54,7 @@ import net.minecraft.world.phys.Vec3;
 import net.minecraft.world.scores.Scoreboard;
 import net.minecraftforge.common.ForgeHooks;
 import net.minecraftforge.common.extensions.IForgePlayer;
+import net.minecraftforge.entity.PartEntity;
 import org.bukkit.Bukkit;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.block.Block;
@@ -372,9 +373,9 @@ public abstract class PlayerMixin extends LivingEntityMixin implements PlayerEnt
                     }
                     EnchantmentHelper.doPostDamageEffects((net.minecraft.world.entity.player.Player) (Object) this, entity);
                     final ItemStack itemstack2 = this.getMainHandItem();
-                    Object object = entity;
-                    if (entity instanceof EnderDragonPart) {
-                        object = ((EnderDragonPart) entity).parentMob;
+                    Entity object = entity;
+                    if (entity instanceof PartEntity) {
+                        object = ((PartEntity<?>) entity).getParent();
                     }
                     if (!this.level.isClientSide && !itemstack2.isEmpty() && object instanceof LivingEntity) {
                         ItemStack copy = itemstack2.copy();


### PR DESCRIPTION
来自1.18.2 official mapping下Player.java第1182行：
```
    // ...
    Entity entity = p_36347_;
    if (p_36347_ instanceof net.minecraftforge.entity.PartEntity) {
        entity = ((net.minecraftforge.entity.PartEntity<?>) p_36347_).getParent();
    }
    // ...
```
而Arclight的实现为：
https://github.com/IzzelAliz/Arclight/blob/d24234803e0d8ebc14592e0b49bf7ba424706c7f/arclight-common/src/main/java/io/izzel/arclight/common/mixin/core/world/entity/player/PlayerMixin.java#L375-L378
可能是原版或者forge在哪个版本更新了这个部分的实现，但Arclight没来得及跟进，这个函数其他部分我稍微对了一下，应该基本是一致的了。