### PR TITLE
Fix horse inventory not init synchronizer (IzzelAliz#657)

### DIFF
--- a/arclight-common/src/main/java/io/izzel/arclight/common/mixin/core/world/entity/player/ServerPlayerMixin.java
+++ b/arclight-common/src/main/java/io/izzel/arclight/common/mixin/core/world/entity/player/ServerPlayerMixin.java
@@ -129,7 +129,7 @@ public abstract class ServerPlayerMixin extends PlayerMixin implements ServerPla
 
     // @formatter:off
     @Shadow @Final public MinecraftServer server;
-    @Shadow  protected abstract int getCoprime(int p_205735_1_);
+    @Shadow protected abstract int getCoprime(int p_205735_1_);
     @Shadow @Final public ServerPlayerGameMode gameMode;
     @Shadow public ServerGamePacketListenerImpl connection;
     @Shadow public abstract boolean isSpectator();
@@ -165,6 +165,7 @@ public abstract class ServerPlayerMixin extends PlayerMixin implements ServerPla
     @Shadow(remap = false) private Component tabListDisplayName;
     @Shadow public abstract void resetFallDistance();
     @Shadow public abstract void shadow$nextContainerCounter();
+    @Shadow public abstract void initMenu(AbstractContainerMenu p_143400_);
     // @formatter:on
 
     public String displayName;
@@ -722,6 +723,7 @@ public abstract class ServerPlayerMixin extends PlayerMixin implements ServerPla
         }
         this.connection.send(new ClientboundHorseScreenOpenPacket(this.containerCounter, iinventory.getContainerSize(), entityhorseabstract.getId()));
         this.containerMenu = container;
+        this.initMenu(this.containerMenu);
         net.minecraftforge.common.MinecraftForge.EVENT_BUS.post(new net.minecraftforge.event.entity.player.PlayerContainerEvent.Open((ServerPlayer) (Object) this, this.containerMenu));
     }
 


### PR DESCRIPTION
修复没有用initMenu绑定synchronizer和slotListener导致马背包无响应的问题
这个类下其他涉及用initMenu绑定的函数都是inject注入的，只有openHorseInventory是用的Overwrite，所以只有马背包有问题

不过这个mixin方法确实不好用inject注入
并且删掉了一个空格