### PR TITLE
[1.19] Add forward permission comment on ko_kr.conf

### DIFF
--- a/i18n-config/src/main/resources/META-INF/i18n/ko_kr.conf
+++ b/i18n-config/src/main/resources/META-INF/i18n/ko_kr.conf
@@ -117,5 +117,10 @@ comments {
       "제대로 작동하지 않는 모드가 있다면, 로그 파일에서 [EXT_LOGIC]와 관련된 클래스 명을"
       "  찾아 여기에 추가해 주세요."
     ]
+    forward-permission.comment = [
+      "true - Forge의 권한 쿼리를 Bukkit으로 넘깁니다."
+      "false - 권한 넘기기를 비활성화합니다."
+      "reverse - Bukkit의 권한 쿼리를 Forge로 넘깁니다."
+    ]
   }
 }


### PR DESCRIPTION
A late fix on translation.
The string has added about 3 months ago from now, so I made a little addition to successfully reflect the update.

Check #724 for 1.18 version. This is for 1.19, since the branch is different.

Added: around the bottom of `ko_kr.conf` I added a comment key and values called `forward-permission.comment`.