### PR TITLE
fix(mixin): prevent crash when dimension isn't set on world border object

### DIFF
--- a/arclight-common/src/main/java/io/izzel/arclight/common/mixin/core/network/play/server/SWorldBorderPacketMixin.java
+++ b/arclight-common/src/main/java/io/izzel/arclight/common/mixin/core/network/play/server/SWorldBorderPacketMixin.java
@@ -19,7 +19,9 @@ public class SWorldBorderPacketMixin {
 
     @Inject(method = "<init>(Lnet/minecraft/world/border/WorldBorder;Lnet/minecraft/network/play/server/SWorldBorderPacket$Action;)V", at = @At("RETURN"))
     private void arclight$nether(WorldBorder border, SWorldBorderPacket.Action actionIn, CallbackInfo ci) {
-        this.centerX = border.getCenterX() * (((WorldBorderBridge) border).bridge$getWorld().getDimensionType().getCoordinateScale());
-        this.centerZ = border.getCenterZ() * (((WorldBorderBridge) border).bridge$getWorld().getDimensionType().getCoordinateScale());
+        if ((((WorldBorderBridge)border).bridge$getWorld() != null)) {
+            this.centerX = border.getCenterX() * (((WorldBorderBridge) border).bridge$getWorld().getDimensionType().getCoordinateScale());
+            this.centerZ = border.getCenterZ() * (((WorldBorderBridge) border).bridge$getWorld().getDimensionType().getCoordinateScale());
+        }
     }
 }


### PR DESCRIPTION
Crash occurs when sending world border packets in pure forge like so:

```java
        WorldBorder worldBorder = new WorldBorder();
        worldBorder.setCenter(border.getCenterX(), border.getCenterZ());
        worldBorder.setAbsoluteMaxSize((int) border.getWorldBorder());
        worldBorder.setSize(border.getWorldBorder());

        ServerPlayerEntity player = (ServerPlayerEntity) event.getPlayer();
        player.connection.send(new SWorldBorderPacket(worldBorder, SWorldBorderPacket.Action.SET_CENTER));
        player.connection.send(new SWorldBorderPacket(worldBorder, SWorldBorderPacket.Action.SET_SIZE));
```