### PR TITLE
fix(mixin): prevent crash in logging interaction handling

### DIFF
--- a/arclight-common/src/main/java/io/izzel/arclight/common/mixin/core/server/management/PlayerInteractionManagerMixin.java
+++ b/arclight-common/src/main/java/io/izzel/arclight/common/mixin/core/server/management/PlayerInteractionManagerMixin.java
@@ -187,7 +187,6 @@ public abstract class PlayerInteractionManagerMixin implements PlayerInteraction
         } else if (action == CPlayerDiggingPacket.Action.ABORT_DESTROY_BLOCK) {
             this.isDestroyingBlock = false;
             if (!Objects.equals(this.destroyPos, blockPos)) {
-                ArclightMod.LOGGER.debug("Mismatch in destroy block pos: " + this.destroyPos + " " + blockPos);
                 this.world.sendBlockBreakProgress(this.player.getEntityId(), this.destroyPos, -1);
                 this.player.connection.sendPacket(new SPlayerDiggingPacket(this.destroyPos, this.world.getBlockState(this.destroyPos), action, true, "aborted mismatched destroying"));
             }


### PR DESCRIPTION
Fixes class not found error when logging in this location:

Crash report here:
[crash-2022-10-14_00.17.15-server1.txt](https://github.com/IzzelAliz/Arclight/files/9795444/crash-2022-10-14_00.17.15-server1.txt)
