### PR TITLE
[Great Horn] Add release name (Horn, GreatHorn) to ko_kr.conf

### DIFF
--- a/i18n-config/src/main/resources/META-INF/i18n/ko_kr.conf
+++ b/i18n-config/src/main/resources/META-INF/i18n/ko_kr.conf
@@ -12,6 +12,13 @@ logo = [
   "    §a빌드 날짜: {}"
   ""
 ]
+# Translate the word in parenthesis only.
+# If there's same Chinese word with same meaning in your language(i.e. Kanji in Japanese), then remove the parenthesis.
+release-name {
+  Horn = "角 (뿔)"
+  GreatHorn = "大角 (큰 뿔)"
+}
+# Note_KOR: Korea once used the mansion system, within Chinese constallation, to define the night sky and the directions.
 java {
   deprecated = [
     "오래된 JAVA 버전을 이용하고 있습니다!"


### PR DESCRIPTION
Traditional korean constallation system uses chinese one, so this could be implemented.
(Koreans don't use kanji enoughly often)

This pull request is for Great Horn Horn (branch `GreatHorn`). For Horn, check out #845.