### PR TITLE
[1.16] Fix StackOverflow when using DUMMY command source

### DIFF
--- a/arclight-common/src/main/java/io/izzel/arclight/common/bridge/command/CommandSourceBridge.java
+++ b/arclight-common/src/main/java/io/izzel/arclight/common/bridge/command/CommandSourceBridge.java
@@ -5,6 +5,8 @@ import org.bukkit.command.CommandSender;
 
 public interface CommandSourceBridge {
 
+    int bridge$getPermissionLevel();
+
     CommandNode<?> bridge$getCurrentCommand();
 
     void bridge$setCurrentCommand(CommandNode<?> node);

--- a/arclight-common/src/main/java/io/izzel/arclight/common/mixin/core/command/CommandSourceMixin.java
+++ b/arclight-common/src/main/java/io/izzel/arclight/common/mixin/core/command/CommandSourceMixin.java
@@ -41,6 +41,11 @@ public abstract class CommandSourceMixin implements CommandSourceBridge {
     }
 
     @Override
+    public int bridge$getPermissionLevel() {
+        return permissionLevel;
+    }
+
+    @Override
     public boolean bridge$hasPermission(int i, String bukkitPermission) {
         return hasPermission(i, bukkitPermission);
     }

--- a/arclight-common/src/main/java/io/izzel/arclight/common/mixin/core/command/ICommandSource1Mixin.java
+++ b/arclight-common/src/main/java/io/izzel/arclight/common/mixin/core/command/ICommandSource1Mixin.java
@@ -1,5 +1,6 @@
 package io.izzel.arclight.common.mixin.core.command;
 
+import io.izzel.arclight.common.bridge.command.CommandSourceBridge;
 import io.izzel.arclight.common.bridge.command.ICommandSourceBridge;
 import net.minecraft.command.CommandSource;
 import org.bukkit.command.CommandSender;
@@ -13,13 +14,10 @@ public class ICommandSource1Mixin implements ICommandSourceBridge {
 
     public CommandSender getBukkitSender(CommandSource wrapper) {
         return new ServerCommandSender() {
-            private Boolean isOp = null;
+            private final boolean isOp = ((CommandSourceBridge)wrapper).bridge$getPermissionLevel()>=wrapper.getServer().getOpPermissionLevel();
 
             @Override
             public boolean isOp() {
-                if (isOp == null) {
-                    isOp = wrapper.hasPermissionLevel(wrapper.getServer().getOpPermissionLevel());
-                }
                 return isOp;
             }
 

--- a/arclight-common/src/main/java/io/izzel/arclight/common/mixin/core/command/ICommandSource1Mixin.java
+++ b/arclight-common/src/main/java/io/izzel/arclight/common/mixin/core/command/ICommandSource1Mixin.java
@@ -13,10 +13,13 @@ public class ICommandSource1Mixin implements ICommandSourceBridge {
 
     public CommandSender getBukkitSender(CommandSource wrapper) {
         return new ServerCommandSender() {
-            private final boolean isOp = wrapper.hasPermissionLevel(wrapper.getServer().getOpPermissionLevel());
+            private Boolean isOp = null;
 
             @Override
             public boolean isOp() {
+                if (isOp == null) {
+                    isOp = wrapper.hasPermissionLevel(wrapper.getServer().getOpPermissionLevel());
+                }
                 return isOp;
             }
 


### PR DESCRIPTION
Turn isOp field as lazy init for prevent endless loop in hasPermissionLevel (introduced by arclight-common/src/main/java/io/izzel/arclight/common/mixin/core/command/CommandSourceMixin.java#hasPermission)