### PR TITLE
Fix level not restored when keepLevel on PlayerDeathEvent

### DIFF
--- a/arclight-common/src/main/java/io/izzel/arclight/common/mixin/core/server/management/PlayerListMixin.java
+++ b/arclight-common/src/main/java/io/izzel/arclight/common/mixin/core/server/management/PlayerListMixin.java
@@ -463,6 +463,9 @@ public abstract class PlayerListMixin implements PlayerListBridge {
                 playerIn.getRespawnAngle(), playerIn.isRespawnForced(), false);
         if (!conqueredEnd) {  // keep inventory here since inventory dropped at ServerPlayerEntity#onDeath
             serverplayerentity.getInventory().replaceWith(playerIn.getInventory());
+            serverplayerentity.experienceLevel = playerIn.experienceLevel;
+            serverplayerentity.totalExperience = playerIn.totalExperience;
+            serverplayerentity.experienceProgress = playerIn.experienceProgress;
         }
         serverplayerentity.setId(playerIn.getId());
         serverplayerentity.setMainArm(playerIn.getMainArm());

--- a/arclight-common/src/main/java/io/izzel/arclight/common/mixin/core/server/management/PlayerListMixin.java
+++ b/arclight-common/src/main/java/io/izzel/arclight/common/mixin/core/server/management/PlayerListMixin.java
@@ -466,6 +466,7 @@ public abstract class PlayerListMixin implements PlayerListBridge {
             serverplayerentity.experienceLevel = playerIn.experienceLevel;
             serverplayerentity.totalExperience = playerIn.totalExperience;
             serverplayerentity.experienceProgress = playerIn.experienceProgress;
+            serverplayerentity.setScore(playerIn.getScore());
         }
         serverplayerentity.setId(playerIn.getId());
         serverplayerentity.setMainArm(playerIn.getMainArm());


### PR DESCRIPTION
Experience and level were not restored on respawn when they were kept via `keepLevel`.