### PR TITLE
Fix `ServerEntity.sendPairingData(Consumer<Packet<?>>, ServerPlayer)`

### DIFF
--- a/arclight-common/src/main/java/io/izzel/arclight/common/mixin/core/server/level/ServerEntityMixin.java
+++ b/arclight-common/src/main/java/io/izzel/arclight/common/mixin/core/server/level/ServerEntityMixin.java
@@ -256,9 +256,13 @@ public abstract class ServerEntityMixin implements ServerEntityBridge {
 
     private transient ServerPlayer arclight$player;
 
-    public void a(final Consumer<Packet<?>> consumer, ServerPlayer playerEntity) {
+    public void sendPairingData(final Consumer<Packet<?>> consumer, ServerPlayer playerEntity) { // CraftBukkit - add player
         this.arclight$player = playerEntity;
         this.sendPairingData(consumer);
+    }
+
+    public void a(final Consumer<Packet<?>> consumer, ServerPlayer playerEntity) { // for backward compatability
+        this.sendPairingData(consumer, playerEntity);
     }
 
     /**


### PR DESCRIPTION
The method is renamed to `sendPairingData` in 1.18 (https://hub.spigotmc.org/stash/projects/SPIGOT/repos/craftbukkit/commits/a7b8b0270a073a6577d0a5bdc6a14f95104f05ea#nms-patches/net/minecraft/server/level/EntityTrackerEntry.patch).