### PR TITLE
fix(url): remove obsolete and unstable mirrors.

### DIFF
--- a/forge-installer/src/main/java/io/izzel/arclight/forgeinstaller/MavenDownloader.java
+++ b/forge-installer/src/main/java/io/izzel/arclight/forgeinstaller/MavenDownloader.java
@@ -5,15 +5,9 @@ import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.StringJoiner;
-import java.util.function.Function;
 import java.util.function.Supplier;
 
 public class MavenDownloader implements Supplier<Path> {
-
-    private static final Function<String, String> FORGE_TO_BMCLAPI =
-        s -> s.replace("https://files.minecraftforge.net/maven/", "https://download.mcbbs.net/maven/")
-            .replace("https://maven.minecraftforge.net/", "https://download.mcbbs.net/maven/");
-
     private final LinkedList<String> urls;
     private final String coord;
     private final String target;
@@ -34,7 +28,6 @@ public class MavenDownloader implements Supplier<Path> {
         this(repos, coord, target, hash);
         if (sourceUrl != null && !this.urls.contains(sourceUrl)) {
             this.urls.addFirst(sourceUrl);
-            this.urls.addFirst(FORGE_TO_BMCLAPI.apply(sourceUrl));
         }
     }
 

--- a/forge-installer/src/main/java/io/izzel/arclight/forgeinstaller/Mirrors.java
+++ b/forge-installer/src/main/java/io/izzel/arclight/forgeinstaller/Mirrors.java
@@ -9,13 +9,10 @@ public class Mirrors {
 
     private static final String[] MAVEN_REPO = {
         "https://arclight.hypertention.cn/",
-        "https://download.mcbbs.net/maven/",
         "https://repo.spongepowered.org/maven/"
     };
 
     private static final String[] MOJANG_MIRROR = {
-        "https://download.mcbbs.net",
-        "https://bmclapi2.bangbang93.com",
         "https://piston-meta.mojang.com"
     };
 


### PR DESCRIPTION
Resolves issues #1200 and #1205, drop obsolete and unstable mirror servers from `MavenDownloader.java` and `Mirrors.java`, users should now be able to download mandatory dependencies.


- [x] Remove obsolete and unstable mirrors.
- [ ] Add replacement mirrors.


MCBBS, one of the largest Minecraft forum in China, has recently suffered from stability issues, and temporarily shutdown on 1 January, 2024, for maintenance expected to last an indeterminate period of time. Therefore, MCBBS mirror servers will be inaccessible until further notice.

Due to this situation, BMCLAPI, a coexisting mirror in `MavenDownloader.java` and `Mirrors.java` experienced a sudden increase in demand, resulting in operational and stability problems. 

This fork/pull request is intended as a temporary solution, until MCBBS restores service, BMCLAPI increases service capacity, or an alternative mirror is proposed. Most users should be able to download mandatory dependencies and start the server with this patch. However, some users might have to add custom mirrors in `MavenDownloader.java` and `Mirrors.java` for it to work.