### PR TITLE
Fix "Invalid payload REGISTER" error when login

### DIFF
--- a/arclight-common/src/main/java/io/izzel/arclight/common/mixin/bukkit/StandardMessengerMixin.java
+++ b/arclight-common/src/main/java/io/izzel/arclight/common/mixin/bukkit/StandardMessengerMixin.java
@@ -1,0 +1,19 @@
+package io.izzel.arclight.common.mixin.bukkit;
+
+import org.bukkit.plugin.messaging.Messenger;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.Constant;
+import org.spongepowered.asm.mixin.injection.ModifyConstant;
+import org.bukkit.plugin.messaging.StandardMessenger;
+
+@Mixin(value=StandardMessenger.class, remap = false)
+public abstract class StandardMessengerMixin implements Messenger {
+
+    @ModifyConstant(
+            method = "validateAndCorrectChannel",
+            constant = @Constant(intValue = Messenger.MAX_CHANNEL_SIZE)
+    )
+    private static int modifyMaxChannelSize(int original) {
+        return 256;
+    }
+}

--- a/arclight-common/src/main/resources/mixins.arclight.bukkit.json
+++ b/arclight-common/src/main/resources/mixins.arclight.bukkit.json
@@ -42,6 +42,7 @@
     "PluginClassLoaderMixin",
     "PotionEffectTypeMixin",
     "RecipeIteratorMixin",
+    "StandardMessengerMixin",
     "WatchdogThreadMixin"
   ]
 }


### PR DESCRIPTION
Some mods' channel names exceed Bukkit's limit. I've modified the limit from 64 to 256 to avoid the ChannelNameTooLongException and the "Invalid payload REGISTER" error when login for some mods, such as [Traffic control + Roads mod by Teerth](https://www.curseforge.com/minecraft/mc-mods/traffic-control-roads-mod-by-teerth/files/all?page=1&pageSize=20)