### PR TITLE
fix: revert to vanilla brewing stand remainder mechanic

### DIFF
--- a/arclight-fabric/src/main/java/io/izzel/arclight/fabric/mixin/core/world/level/block/entity/BrewingStandBlockEntityMixin_Fabric.java
+++ b/arclight-fabric/src/main/java/io/izzel/arclight/fabric/mixin/core/world/level/block/entity/BrewingStandBlockEntityMixin_Fabric.java
@@ -36,16 +36,14 @@ public class BrewingStandBlockEntityMixin_Fabric {
             return;
         }
 
+        itemStack.shrink(1);
         if (itemStack.getItem().hasCraftingRemainingItem()) {
             ItemStack itemStack2 = new ItemStack(itemStack.getItem().getCraftingRemainingItem());
-            itemStack.shrink(1);
             if (itemStack.isEmpty()) {
                 itemStack = itemStack2;
             } else {
                 Containers.dropItemStack(level, pos.getX(), pos.getY(), pos.getZ(), itemStack2);
             }
-        } else {
-            itemStack.shrink(1);
         }
 
         stacks.set(3, itemStack);


### PR DESCRIPTION
Fabric API (https://github.com/FabricMC/fabric/blob/1.20.4/fabric-item-api-v1/src/main/java/net/fabricmc/fabric/mixin/item/BrewingStandBlockEntityMixin.java) modifies the last remainder mechanic, so there is no need to fix it on the Arclight side and it actually causes a mixin conflict:

```
java.lang.NullPointerException: Cannot invoke "net.minecraft.class_1799.method_7960()" because the return value of "java.lang.ThreadLocal.get()" is null
	at net.minecraft.class_2589.redirect$cff000$fabric-item-api-v1$hasStackRecipeRemainder(BrewingStandBlockEntityMixin_Fabric.java:1547)
	at net.minecraft.class_2589.method_11029(BrewingStandBlockEntityMixin_Fabric.java:1039)
	at net.minecraft.class_2589.method_31665(BrewingStandBlockEntityMixin_Fabric.java:128)
	at net.minecraft.class_2818$class_5563.method_31703(LevelChunk_BoundTickingBlockEntityMixin.java:662)
	at net.minecraft.class_2818$class_5564.method_31703(class_2818.java:716)
	at net.minecraft.class_1937.method_18471(LevelMixin.java:482)
	at net.minecraft.class_3218.method_18765(ServerLevelMixin.java:404)
	at net.minecraft.server.MinecraftServer.method_3813(MinecraftServerMixin.java:948)
	at net.minecraft.class_3176.method_3813(DedicatedServerMixin_Vanilla.java:283)
	at net.minecraft.server.MinecraftServer.method_3748(MinecraftServerMixin.java:845)
	at net.minecraft.server.MinecraftServer.method_29741(MinecraftServerMixin.java:2126)
	at net.minecraft.server.MinecraftServer.method_29739(MinecraftServerMixin.java:270)
	at java.base/java.lang.Thread.run(Thread.java:842)
```