### PR TITLE
[Whisper] Update korean i18n (ko-kr.conf)

### DIFF
--- a/i18n-config/src/main/resources/META-INF/i18n/ko_kr.conf
+++ b/i18n-config/src/main/resources/META-INF/i18n/ko_kr.conf
@@ -21,6 +21,8 @@ release-name {
   GreatHorn = "大角 (대각)"
   Executions = "折威 (절위)"
   Trials = "頓頑 (돈완)"
+  Net = "毕宿 (Net)"
+  Whisper = "附耳 (Whisper)"
 }
 java {
   deprecated = [
@@ -80,6 +82,8 @@ dfu-disable {
   map-convert = "optimization.disable-data-fixer가 활성화되어 있으면 월드의 업그레이드가 불가합니다."
 }
 error-symlink = "파일 시스템이 symbolic link를 지원하지 않습니다."
+symlink-file-exist = "A file already exists when creating symlink {}"
+lightcity-not-installed = "This server requires Lightcity plugin installed on your Velocity proxy"
 
 comments {
   _v.comment = [
@@ -92,12 +96,6 @@ comments {
   locale.comment = "언어/I18n 설정"
   optimization {
     comment = "최적화 관련 설정"
-    disable-data-fixer.comment = [
-      "레벨 데이터 업그레이드에 이용되는 DataFixerUpper 시스템을 비활성화합니다."
-      "서버 시작과 월드 로드 속도를 올리고, 메모리 사용량을 80~200MB까지 줄일 수 있습니다."
-      "Arclight 및 개발자는 데이터 손실을 책임지지 않습니다."
-      "상용 서버에서는 사용하지 마십시오!"
-    ]
     goal-selector-update-interval.comment = [
       "목표 선택기가 업데이트되는 시간(틱 단위)을 설정합니다."
       "높은 값은 더 적은 리소스를 소모합니다."
@@ -131,6 +129,21 @@ comments {
       "true - Forge의 권한 쿼리를 Bukkit으로 넘깁니다."
       "false - 권한 넘기기를 비활성화합니다."
       "reverse - Bukkit의 권한 쿼리를 Forge로 넘깁니다."
+    ]
+    valid-username-regex.comment = [
+      "유효한 사용자명(ID)을 검사할 때 사용하는 정규식을 설정합니다. 빈 칸으로 두면 바닐라 설정을 적용합니다."
+      "다음은 중국어를 허용합니다:"
+      "valid-username-regex = \"^[ -~\\\\p{sc=Han}]{1,16}$\""
+      "다음은 모든 ID를 허용합니다:"
+      "valid-username-regex = \".+\""
+    ]
+  }
+  velocity {
+    enable.comment = [
+      "Enable Velocity modern player info forwarding"
+    ]
+    secret.comment = [
+      "The secret used in Velocity modern player info forwarding"
     ]
   }
 }

--- a/i18n-config/src/main/resources/META-INF/i18n/ko_kr.conf
+++ b/i18n-config/src/main/resources/META-INF/i18n/ko_kr.conf
@@ -21,8 +21,8 @@ release-name {
   GreatHorn = "大角 (대각)"
   Executions = "折威 (절위)"
   Trials = "頓頑 (돈완)"
-  Net = "毕宿 (Net)"
-  Whisper = "附耳 (Whisper)"
+  Net = "毕宿 (자후)"
+  Whisper = "附耳 (부이)"
 }
 java {
   deprecated = [
@@ -42,7 +42,7 @@ i18n {
 }
 loading-mapping = "맵핑 로드 중..."
 mixin-load {
-  core = "Arclight core mixin 적용됨"
+  core = "Arclight 핵심 mixin 적용됨"
   optimization = "Arclight 최적화 mixin 적용됨"
 }
 mod-load = "Arclight 모드 로드됨"
@@ -63,18 +63,18 @@ registry {
   villager-profession = "신규 주민 직업({}종) 적용 완료"
   biome = "신규 바이옴({}종) 적용 완료"
   meta-type {
-    not-subclass = "{} is not a subclass of {}"
-    error = "{} provided itemMetaType {} is invalid: {}"
-    no-candidate = "{} do not found a valid constructor in prodived itemMetaType {}"
+    not-subclass = "{}은(는) {}의 하위 클래스가 아닙니다"
+    error = "{}이(가) 제공한 itemMetaType {}가 유효하지 않음: {}"
+    no-candidate = "{}이(가) 제공된 itemMetaType {}에서 유효한 constructor를 찾지 못했습니다"
   }
   block-state {
-    not-subclass = "{} is not a subclass of {}"
-    error = "{} prodived itemMetaType {} is invalid {}"
-    no-candidate = "{} do not found a valid constructor in provided blockStateClass {}"
+    not-subclass = "{}은(는) {}의 하위 클래스가 아닙니다"
+    error = "{}이(가) 제공한 itemMetaType {}이(가) 유효하지 않음: {}"
+    no-candidate = "{}이(가) 제공된 blockStateClass {}에서 유효한 constructor를 찾지 못했습니다"
   }
   entity {
-    not-subclass = "{} is not a subclass of {}"
-    error = "{} prodived entityClass {} is invalid: {}"
+    not-subclass = "{}은(는) {}의 하위 클래스가 아닙니다"
+    error = "{}이(가) 제공된 entityClass {}이(가) 유효하지 않음: {}"
   }
 }
 dfu-disable {
@@ -82,8 +82,8 @@ dfu-disable {
   map-convert = "optimization.disable-data-fixer가 활성화되어 있으면 월드의 업그레이드가 불가합니다."
 }
 error-symlink = "파일 시스템이 symbolic link를 지원하지 않습니다."
-symlink-file-exist = "A file already exists when creating symlink {}"
-lightcity-not-installed = "This server requires Lightcity plugin installed on your Velocity proxy"
+symlink-file-exist = "파일 {}이 이미 존재해 symlink를 생성하지 못했습니다"
+lightcity-not-installed = "이 서버는 Velocity 프록시에 Lightcity 플러그인이 설치되어 있어야 동작합니다"
 
 comments {
   _v.comment = [
@@ -91,7 +91,7 @@ comments {
     "이슈 트래커(영문, 중문): https://github.com/IzzelAliz/Arclight/issues"
     ""
     ""
-    "Config version number, do not edit."
+    "설정의 버전 숫자는 수정하지 마세요."
   ]
   locale.comment = "언어/I18n 설정"
   optimization {
@@ -140,10 +140,10 @@ comments {
   }
   velocity {
     enable.comment = [
-      "Enable Velocity modern player info forwarding"
+      "Velocoty의 모던 플레이어 정보 포워딩을 허용합니다"
     ]
     secret.comment = [
-      "The secret used in Velocity modern player info forwarding"
+      "Velocity 모던 플레이어 포워딩의 secret값입니다"
     ]
   }
 }


### PR DESCRIPTION
Time has passed from #1037 , and there were some huge changes. However, the i18n for Korean (which I lastly managed) is not updated- quite a lot that the default fallback, Classic Chinese, would appear even the setting is correct as Korean.
So for now, I'm making this PR to update the i18n file to fix that issue.

`ko-kr.conf`:
- release-name: Add `毕宿 (Net)` and `附耳 (Whisper)`, untranslated from `en-us`
- dfu-disable: Add `symlink-file-exist` and `lightcity-not-installed`, untranslated from `en-us`
- comments: Remove `optimization.disable-data-fixer.comment`
- comments: Add `compatibility.valid-username-regex.comment` and `velocity.*`
  - `velocity.*` is untranslated from `en-us`