### PR TITLE
feat: use arclight-server-launch.properties file to discover main class

### DIFF
--- a/bootstrap/build.gradle
+++ b/bootstrap/build.gradle
@@ -141,7 +141,6 @@ tasks.register('forgeJar', Jar) {
     manifest.attributes 'Implementation-Vendor': 'Arclight Team'
     manifest.attributes 'Implementation-Timestamp': new Date().format("yyyy-MM-dd HH:mm:ss")
     manifest.attributes 'Automatic-Module-Name': 'arclight.boot'
-    manifest.attributes 'Arclight-Target': 'io.izzel.arclight.boot.forge.application.Main_Forge'
     from(configurations.embed.collect { it.isDirectory() ? it : zipTree(it) }) {
         exclude "META-INF/MANIFEST.MF"
         exclude "META-INF/*.SF"
@@ -174,7 +173,6 @@ tasks.register('neoforgeJar', Jar) {
     manifest.attributes 'Implementation-Vendor': 'Arclight Team'
     manifest.attributes 'Implementation-Timestamp': new Date().format("yyyy-MM-dd HH:mm:ss")
     manifest.attributes 'Automatic-Module-Name': 'arclight.boot'
-    manifest.attributes 'Arclight-Target': 'io.izzel.arclight.boot.neoforge.application.Main_Neoforge'
     from(configurations.embed.collect { it.isDirectory() ? it : zipTree(it) }) {
         exclude "META-INF/MANIFEST.MF"
         exclude "META-INF/*.SF"
@@ -207,7 +205,6 @@ tasks.register('fabricJar', Jar) {
     manifest.attributes 'Implementation-Vendor': 'Arclight Team'
     manifest.attributes 'Implementation-Timestamp': new Date().format("yyyy-MM-dd HH:mm:ss")
     manifest.attributes 'Automatic-Module-Name': 'arclight.boot'
-    manifest.attributes 'Arclight-Target': 'io.izzel.arclight.boot.fabric.application.Main_Fabric'
     from(configurations.embedFabric.collect { it.isDirectory() ? it : zipTree(it) })
     into('/') {
         it.from(project(':arclight-fabric').tasks.reobfJar.outputs.files.collect())

--- a/bootstrap/src/applaunch/java/io/izzel/arclight/server/Launcher.java
+++ b/bootstrap/src/applaunch/java/io/izzel/arclight/server/Launcher.java
@@ -4,7 +4,7 @@ import java.io.InputStream;
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodType;
-import java.util.jar.Manifest;
+import java.util.Properties;
 
 public class Launcher {
 
@@ -30,9 +30,11 @@ public class Launcher {
             Thread.sleep(3000);
         }
 
-        try (InputStream input = Launcher.class.getResourceAsStream("/META-INF/MANIFEST.MF")) {
-            Manifest manifest = new Manifest(input);
-            String target = manifest.getMainAttributes().getValue("Arclight-Target");
+        try (InputStream input = Launcher.class.getResourceAsStream("/arclight-server-launch.properties")) {
+            Properties properties = new Properties();
+            properties.load(input);
+
+            String target = properties.getProperty("launch.mainClass");
             MethodHandle main = MethodHandles.lookup().findStatic(Class.forName(target), "main", MethodType.methodType(void.class, String[].class));
             main.invoke((Object) args);
         }

--- a/bootstrap/src/fabric/resources/arclight-server-launch.properties
+++ b/bootstrap/src/fabric/resources/arclight-server-launch.properties
@@ -1,0 +1,1 @@
+launch.mainClass=io.izzel.arclight.boot.fabric.application.Main_Fabric

--- a/bootstrap/src/forge/resources/arclight-server-launch.properties
+++ b/bootstrap/src/forge/resources/arclight-server-launch.properties
@@ -1,0 +1,1 @@
+launch.mainClass=io.izzel.arclight.boot.forge.application.Main_Forge

--- a/bootstrap/src/neoforge/resources/arclight-server-launch.properties
+++ b/bootstrap/src/neoforge/resources/arclight-server-launch.properties
@@ -1,0 +1,1 @@
+launch.mainClass=io.izzel.arclight.boot.neoforge.application.Main_Neoforge


### PR DESCRIPTION
As discussed in [discord](https://discord.com/channels/711137270052421653/711137270484172862/1246424193495597137) this PR introduces a new file that contains the main classes for forge, neoforge & fabric.

The manifest file is not a great place for the property because you might have other dependency on the classpath and therefore the manifest might be overwritten.