### PR TITLE
Update gradle-wrapper.properties

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 #Sun Feb 09 15:27:43 CST 2020
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.8-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-all.zip
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists


### PR DESCRIPTION
You are using Java 21 for Minecraft 1.21
Use Gradle 8.5 instead of 8.8

https://docs.gradle.org/current/userguide/compatibility.html#java

Make sure you must setup 
...\Arclight-FeudalKings\arclight-common\build.gradle' line: 7

A problem occurred evaluating project ':arclight-common'.
> Failed to apply plugin class 'net.fabricmc.loom.bootstrap.LoomGradlePluginBootstrap'.
   > You are using an outdated version of Gradle (8.5). Gradle 8.8 or higher is required.