### PR TITLE
Fix IllegalArgumentException: Cannot copy null stack in ItemStackMixin_NeoForge

### DIFF
--- a/arclight-neoforge/src/main/java/io/izzel/arclight/neoforge/mixin/core/world/item/ItemStackMixin_NeoForge.java
+++ b/arclight-neoforge/src/main/java/io/izzel/arclight/neoforge/mixin/core/world/item/ItemStackMixin_NeoForge.java
@@ -37,16 +37,15 @@ public abstract class ItemStackMixin_NeoForge implements ItemStackBridge, IItemS
     @Shadow private int count;
     // @formatter:on
 
-
-    @Decorate(method = "hurtAndBreak(ILnet/minecraft/server/level/ServerLevel;Lnet/minecraft/world/entity.LivingEntity;Ljava/util.function.Consumer;)V",
-            at = @At(value = "INVOKE", target = "Lnet/minecraft/world/item/enchantment/EnchantmentHelper.processDurabilityChange(Lnet/minecraft/server/level/ServerLevel;Lnet/minecraft/world/item.ItemStack;I)I"))
-    private int arclight$itemDamage(ServerLevel serverLevel, ItemStack itemStack, int i, @Local(ordinal = 0) LivingEntity damager) throws Throwable {
+    @Decorate(method = "hurtAndBreak",
+            at = @At(value = "INVOKE", target = "Lnet/minecraft/world/item/enchantment/EnchantmentHelper;processDurabilityChange(Lnet/minecraft/world/item/ItemStack;I)I"))
+    private int arclight$itemDamage(ServerLevel serverLevel, ItemStack itemStack, int damage, @Local(ordinal = 0) LivingEntity damager) {
         // Ensure the itemStack is not null
         if (itemStack == null) {
             itemStack = ItemStack.EMPTY;
         }
 
-        int result = (int) DecorationOps.callsite().invoke(serverLevel, itemStack, i);
+        int result = (int) DecorationOps.callsite().invoke(serverLevel, itemStack, damage);
         if (damager instanceof ServerPlayer) {
             PlayerItemDamageEvent event = new PlayerItemDamageEvent(((ServerPlayerEntityBridge) damager).bridge$getBukkitEntity(), CraftItemStack.asCraftMirror((ItemStack) (Object) this), result);
             event.getPlayer().getServer().getPluginManager().callEvent(event);
@@ -62,7 +61,8 @@ public abstract class ItemStackMixin_NeoForge implements ItemStackBridge, IItemS
         return result;
     }
 
-    @Inject(method = "hurtAndBreak(ILnet/minecraft/server/level/ServerLevel;Lnet/minecraft/world/entity/LivingEntity;Ljava/util/function/Consumer;)V", at = @At(value = "INVOKE", target = "Ljava/util/function/Consumer;accept(Ljava/lang/Object;)V"))
+    @Inject(method = "hurtAndBreak(ILnet/minecraft/server/level/ServerLevel;Lnet/minecraft/world/entity/LivingEntity;Ljava/util/function/Consumer;)V", 
+            at = @At(value = "INVOKE", target = "Ljava/util/function/Consumer;accept(Ljava/lang/Object;)V"))
     private void arclight$itemBreak(int amount, ServerLevel level, @org.jetbrains.annotations.Nullable LivingEntity livingEntity, Consumer<Item> onBroken, CallbackInfo ci) {
         if (this.count == 1 && livingEntity instanceof ServerPlayer serverPlayer) {
             CraftEventFactory.callPlayerItemBreakEvent(serverPlayer, (ItemStack) (Object) this);
@@ -70,10 +70,7 @@ public abstract class ItemStackMixin_NeoForge implements ItemStackBridge, IItemS
     }
 
     @Deprecated
-    public void setItem(@Nullable Item item) {
-        if (item == null) {
-            return;
-        }
+    public void setItem(Item item) {
         this.item = item;
     }
 

--- a/arclight-neoforge/src/main/java/io/izzel/arclight/neoforge/mixin/core/world/item/ItemStackMixin_NeoForge.java
+++ b/arclight-neoforge/src/main/java/io/izzel/arclight/neoforge/mixin/core/world/item/ItemStackMixin_NeoForge.java
@@ -37,15 +37,13 @@ public abstract class ItemStackMixin_NeoForge implements ItemStackBridge, IItemS
     @Shadow private int count;
     // @formatter:on
 
-    @Decorate(method = "hurtAndBreak",
-            at = @At(value = "INVOKE", target = "Lnet/minecraft/world/item/enchantment/EnchantmentHelper;processDurabilityChange(Lnet/minecraft/world/item/ItemStack;I)I"))
-    private int arclight$itemDamage(ServerLevel serverLevel, ItemStack itemStack, int damage, @Local(ordinal = 0) LivingEntity damager) {
-        // Ensure the itemStack is not null
+    @Decorate(method = "hurtAndBreak(ILnet/minecraft/server/level/ServerLevel;Lnet/minecraft/world/entity/LivingEntity;Ljava/util/function/Consumer;)V",
+            at = @At(value = "INVOKE", target = "Lnet/minecraft/world/item/enchantment/EnchantmentHelper;processDurabilityChange(Lnet/minecraft/server/level/ServerLevel;Lnet/minecraft/world/item/ItemStack;I)I"))
+    private int arclight$itemDamage(ServerLevel serverLevel, ItemStack itemStack, int i, @Local(ordinal = 0) LivingEntity damager) throws Throwable {
         if (itemStack == null) {
             itemStack = ItemStack.EMPTY;
         }
-
-        int result = (int) DecorationOps.callsite().invoke(serverLevel, itemStack, damage);
+        int result = (int) DecorationOps.callsite().invoke(serverLevel, itemStack, i);
         if (damager instanceof ServerPlayer) {
             PlayerItemDamageEvent event = new PlayerItemDamageEvent(((ServerPlayerEntityBridge) damager).bridge$getBukkitEntity(), CraftItemStack.asCraftMirror((ItemStack) (Object) this), result);
             event.getPlayer().getServer().getPluginManager().callEvent(event);
@@ -61,8 +59,7 @@ public abstract class ItemStackMixin_NeoForge implements ItemStackBridge, IItemS
         return result;
     }
 
-    @Inject(method = "hurtAndBreak(ILnet/minecraft/server/level/ServerLevel;Lnet/minecraft/world/entity/LivingEntity;Ljava/util/function/Consumer;)V", 
-            at = @At(value = "INVOKE", target = "Ljava/util/function/Consumer;accept(Ljava/lang/Object;)V"))
+    @Inject(method = "hurtAndBreak(ILnet/minecraft/server/level/ServerLevel;Lnet/minecraft/world/entity/LivingEntity;Ljava/util/function/Consumer;)V", at = @At(value = "INVOKE", target = "Ljava/util/function/Consumer;accept(Ljava/lang/Object;)V"))
     private void arclight$itemBreak(int amount, ServerLevel level, @org.jetbrains.annotations.Nullable LivingEntity livingEntity, Consumer<Item> onBroken, CallbackInfo ci) {
         if (this.count == 1 && livingEntity instanceof ServerPlayer serverPlayer) {
             CraftEventFactory.callPlayerItemBreakEvent(serverPlayer, (ItemStack) (Object) this);
@@ -70,7 +67,9 @@ public abstract class ItemStackMixin_NeoForge implements ItemStackBridge, IItemS
     }
 
     @Deprecated
-    public void setItem(Item item) {
+    public void setItem(@Nullable Item item) {
+        if (item == null) { return;
+        }
         this.item = item;
     }
 

--- a/arclight-neoforge/src/main/java/io/izzel/arclight/neoforge/mixin/core/world/item/ItemStackMixin_NeoForge.java
+++ b/arclight-neoforge/src/main/java/io/izzel/arclight/neoforge/mixin/core/world/item/ItemStackMixin_NeoForge.java
@@ -38,8 +38,13 @@ public abstract class ItemStackMixin_NeoForge implements ItemStackBridge, IItemS
     // @formatter:on
 
     @Decorate(method = "hurtAndBreak(ILnet/minecraft/server/level/ServerLevel;Lnet/minecraft/world/entity/LivingEntity;Ljava/util/function/Consumer;)V",
-        at = @At(value = "INVOKE", target = "Lnet/minecraft/world/item/enchantment/EnchantmentHelper;processDurabilityChange(Lnet/minecraft/server/level/ServerLevel;Lnet/minecraft/world/item/ItemStack;I)I"))
+            at = @At(value = "INVOKE", target = "Lnet/minecraft/world/item/enchantment/EnchantmentHelper;processDurabilityChange(Lnet/minecraft/server/level/ServerLevel;Lnet/minecraft/world/item/ItemStack;I)I"))
     private int arclight$itemDamage(ServerLevel serverLevel, ItemStack itemStack, int i, @Local(ordinal = 0) LivingEntity damager) throws Throwable {
+        // Added null check for itemStack
+        if (itemStack == null) {
+            return 0;
+        }
+
         int result = (int) DecorationOps.callsite().invoke(serverLevel, itemStack, i);
         if (damager instanceof ServerPlayer) {
             PlayerItemDamageEvent event = new PlayerItemDamageEvent(((ServerPlayerEntityBridge) damager).bridge$getBukkitEntity(), CraftItemStack.asCraftMirror((ItemStack) (Object) this), result);
@@ -64,7 +69,7 @@ public abstract class ItemStackMixin_NeoForge implements ItemStackBridge, IItemS
     }
 
     @Deprecated
-    public void setItem(Item item) {
+    public void setItem(@Nullable Item item) {
         this.item = item;
     }
 

--- a/arclight-neoforge/src/main/java/io/izzel/arclight/neoforge/mixin/core/world/item/ItemStackMixin_NeoForge.java
+++ b/arclight-neoforge/src/main/java/io/izzel/arclight/neoforge/mixin/core/world/item/ItemStackMixin_NeoForge.java
@@ -16,8 +16,8 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.context.UseOnContext;
 import net.minecraft.world.level.LevelReader;
 import net.neoforged.neoforge.common.extensions.IItemStackExtension;
-import org.bukkit.craftbukkit.v1_21_R1.event.CraftEventFactory;
-import org.bukkit.craftbukkit.v1_21_R1.inventory.CraftItemStack;
+import org.bukkit.craftbukkit.v.event.CraftEventFactory;
+import org.bukkit.craftbukkit.v.inventory.CraftItemStack;
 import org.bukkit.event.player.PlayerItemDamageEvent;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Mutable;
@@ -32,14 +32,14 @@ import java.util.function.Consumer;
 @Mixin(ItemStack.class)
 public abstract class ItemStackMixin_NeoForge implements ItemStackBridge, IItemStackExtension {
 
-     // @formatter:off
+    // @formatter:off
     @Mutable @Shadow @Deprecated @Nullable private Item item;
     @Shadow private int count;
     // @formatter:on
 
 
     @Decorate(method = "hurtAndBreak(ILnet/minecraft/server/level/ServerLevel;Lnet/minecraft/world/entity.LivingEntity;Ljava/util.function.Consumer;)V",
-        at = @At(value = "INVOKE", target = "Lnet/minecraft/world/item/enchantment/EnchantmentHelper.processDurabilityChange(Lnet/minecraft/server/level/ServerLevel;Lnet/minecraft/world/item.ItemStack;I)I"))
+            at = @At(value = "INVOKE", target = "Lnet/minecraft/world/item/enchantment/EnchantmentHelper.processDurabilityChange(Lnet/minecraft/server/level/ServerLevel;Lnet/minecraft/world/item.ItemStack;I)I"))
     private int arclight$itemDamage(ServerLevel serverLevel, ItemStack itemStack, int i, @Local(ordinal = 0) LivingEntity damager) throws Throwable {
         // Ensure the itemStack is not null
         if (itemStack == null) {
@@ -62,16 +62,18 @@ public abstract class ItemStackMixin_NeoForge implements ItemStackBridge, IItemS
         return result;
     }
 
-    @Inject(method = "hurtAndBreak(ILnet/minecraft/server/level/ServerLevel;Lnet/minecraft/world/entity.LivingEntity;Ljava/util.function/Consumer;)V",
-            at = @At(value = "INVOKE", target = "Ljava/util.function.Consumer.accept(Ljava.lang.Object;)V"))
-    private void arclight$itemBreak(int amount, ServerLevel level, @Nullable LivingEntity livingEntity, Consumer<Item> onBroken, CallbackInfo ci) {
+    @Inject(method = "hurtAndBreak(ILnet/minecraft/server/level/ServerLevel;Lnet/minecraft/world/entity/LivingEntity;Ljava/util/function/Consumer;)V", at = @At(value = "INVOKE", target = "Ljava/util/function/Consumer;accept(Ljava/lang/Object;)V"))
+    private void arclight$itemBreak(int amount, ServerLevel level, @org.jetbrains.annotations.Nullable LivingEntity livingEntity, Consumer<Item> onBroken, CallbackInfo ci) {
         if (this.count == 1 && livingEntity instanceof ServerPlayer serverPlayer) {
-            CraftEventFactory.callPlayerItemBreakEvent(serverPlayer, CraftItemStack.asCraftMirror((ItemStack) (Object) this));
+            CraftEventFactory.callPlayerItemBreakEvent(serverPlayer, (ItemStack) (Object) this);
         }
     }
 
     @Deprecated
-    public void setItem(Item item) {
+    public void setItem(@Nullable Item item) {
+        if (item == null) {
+            return;
+        }
         this.item = item;
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ allprojects {
         fabricLoaderVersion = '0.16.9'
         fabricApiVersion = '0.108.0+1.21.1'
         forgeVersion = '52.0.28'
-        neoForgeVersion = '21.1.77'
+        neoForgeVersion = '21.1.79'
         apiVersion = '1.7.3'
         toolsVersion = '1.3.0'
         mixinVersion = '0.8.5'


### PR DESCRIPTION
Fixes IllegalArgumentException: Cannot copy null stack reported in server logs.