### PR TITLE
Fix multiworld conflict

### DIFF
--- a/arclight-common/src/main/java/io/izzel/arclight/common/mod/util/DistValidate.java
+++ b/arclight-common/src/main/java/io/izzel/arclight/common/mod/util/DistValidate.java
@@ -32,9 +32,8 @@ public class DistValidate {
     }
 
     private static boolean isLogicWorld(LevelAccessor level) {
-        var cl = level.getClass();
-        return cl == ServerLevel.class || cl == WorldGenRegion.class
-            || isLogicWorld(cl);
+        return level instanceof ServerLevel || level instanceof WorldGenRegion
+            || isLogicWorld(level.getClass());
     }
 
     private static final Map<Class<?>, Boolean> SEEN_CLASSES = new ConcurrentHashMap<>();


### PR DESCRIPTION
I don't know why classes are being compared instead of using `instanceof`, but this solves at least the following problem:

- https://github.com/IzzelAliz/Arclight/issues/1589

Although it could be done differently by adding `xyz.nucleoid.fantasy.RuntimeWorld` in the config to `extra-logic-worlds`