### PR TITLE
Avoid UB in installer and check manifest data in advance

### DIFF
--- a/arclight-forge/src/main/java/io/izzel/arclight/boot/AbstractBootstrap.java
+++ b/arclight-forge/src/main/java/io/izzel/arclight/boot/AbstractBootstrap.java
@@ -28,7 +28,6 @@ import java.nio.file.Paths;
 import java.util.Map;
 import java.util.jar.Attributes;
 import java.util.jar.Manifest;
-import java.util.stream.Collectors;
 
 public class AbstractBootstrap {
 
@@ -91,13 +90,14 @@ public class AbstractBootstrap {
 
     protected void setupMod() throws Exception {
         ArclightVersion.setVersion(ArclightVersion.TRIALS);
+        var logger = LogManager.getLogger("Arclight");
         try (InputStream stream = getClass().getModule().getResourceAsStream("/META-INF/MANIFEST.MF")) {
             Manifest manifest = new Manifest(stream);
             Attributes attributes = manifest.getMainAttributes();
             String version = attributes.getValue(Attributes.Name.IMPLEMENTATION_VERSION);
             extract(getClass().getModule().getResourceAsStream("/common.jar"), version);
             String buildTime = attributes.getValue("Implementation-Timestamp");
-            LogManager.getLogger("Arclight").info(ArclightLocale.getInstance().get("logo"),
+            logger.info(ArclightLocale.getInstance().get("logo"),
                 ArclightLocale.getInstance().get("release-name." + ArclightVersion.current().getReleaseName()), version, buildTime);
         }
     }
@@ -110,7 +110,7 @@ public class AbstractBootstrap {
         }
         var mod = dir.resolve(version + ".jar");
         if (!Files.exists(mod) || Boolean.getBoolean("arclight.alwaysExtract")) {
-            for (Path old : Files.list(dir).collect(Collectors.toList())) {
+            for (Path old : Files.list(dir).toList()) {
                 Files.delete(old);
             }
             Files.copy(path, mod);

--- a/arclight-forge/src/main/java/io/izzel/arclight/boot/application/BootstrapTransformer.java
+++ b/arclight-forge/src/main/java/io/izzel/arclight/boot/application/BootstrapTransformer.java
@@ -1,0 +1,111 @@
+package io.izzel.arclight.boot.application;
+
+import cpw.mods.cl.ModuleClassLoader;
+import io.izzel.arclight.api.Unsafe;
+import org.objectweb.asm.*;
+import org.objectweb.asm.tree.*;
+
+import java.io.IOException;
+import java.security.ProtectionDomain;
+import java.util.Map;
+import java.util.function.BiFunction;
+
+public class BootstrapTransformer {
+    private static final Map<String, BiFunction<ClassLoader, ProtectionDomain, Exception>> SUPPORTED = Map.of(
+            "cpw.mods.bootstraplauncher.BootstrapLauncher",
+            BootstrapTransformer::transformBootstrapLauncher
+    );
+
+    public static Class<?> loadTransform(String className, ClassLoader cl, ProtectionDomain domain) throws Exception {
+        if (!SUPPORTED.containsKey(className)) {
+            throw new UnsupportedOperationException("Transformation for "+className+" is not supported");
+        }
+        var ex = SUPPORTED.get(className).apply(cl, domain);
+        if (ex != null) throw ex;
+        return cl.loadClass(className);
+    }
+
+    /*
+     * Previous implementation of BootstrapLauncher relies on the order of ServiceLoader.load().stream()
+     * where the ApplicationBootstrap will be ahead of modlauncher, which is an UB related to module name.
+     * Modify BootstrapLauncher to use ApplicationBootstrap directly so a change in module name won't
+     * affect launch process.
+     */
+    public static Exception transformBootstrapLauncher(ClassLoader cl, ProtectionDomain domain) {
+        final var cpwClassName = "cpw.mods.bootstraplauncher.BootstrapLauncher";
+        final var cpwClassFile = "cpw/mods/bootstraplauncher/BootstrapLauncher.class";
+        System.out.println("Transforming " + cpwClassName);
+        try(var inputStream = cl.getResourceAsStream(cpwClassFile)) {
+            if (inputStream == null) {
+                return new IOException("getResourceAsStream can't read BootstrapLauncher.class");
+            }
+            var asmClass = new ClassNode();
+            new ClassReader(inputStream).accept(asmClass, 0);
+            // Find main(String[])
+            MethodNode asmMain = null;
+            for (var asmMethod : asmClass.methods) {
+                if ("main".equals(asmMethod.name)) {
+                    asmMain = asmMethod;
+                    break;
+                }
+            }
+            if (asmMain == null) {
+                return new NullPointerException("Cannot find main(String[]) in BootstrapLauncher");
+            }
+            // Apply transformation
+            var insns = asmMain.instructions;
+            var injected = false;
+            for (int i = 0; i < insns.size(); i++) {
+                if (insns.get(i) instanceof MethodInsnNode invoke) {
+                    if ("java/util/function/Consumer".equals(invoke.owner)
+                            && "accept".equals(invoke.name)) {
+                        // Raw: [SERVICE].accept(args);
+                        // Modified: ((Consumer)new ApplicationBootstrap()).accept(args);
+                        var createArclightBoot = new InsnList();
+                        {
+                            var popArgsThenService = new InsnNode(Opcodes.POP2);
+                            var aloadArgs = new VarInsnNode(Opcodes.ALOAD, 0);
+                            var aloadModuleCl = new VarInsnNode(Opcodes.ALOAD, 15);
+                            var onInvoke = new MethodInsnNode(
+                                    Opcodes.INVOKESTATIC,
+                                    "io/izzel/arclight/boot/application/BootstrapTransformer",
+                                    "onInvoke$BootstrapLauncher",
+                                    "([Ljava/lang/String;Lcpw/mods/cl/ModuleClassLoader;)V"
+                            );
+                            createArclightBoot.add(popArgsThenService);
+                            createArclightBoot.add(aloadArgs);
+                            createArclightBoot.add(aloadModuleCl);
+                            createArclightBoot.add(onInvoke);
+                        }
+                        insns.insert(invoke, createArclightBoot);
+                        insns.remove(invoke);
+                        injected = true;
+                        break;
+                    }
+                }
+            }
+            if (!injected) {
+                return new Exception("BootstrapTransformer failed to transform BootstrapLauncher: Consumer.accept(String[]) not found");
+            }
+            // Save and define transformed class
+            var cw = new ClassWriter(ClassWriter.COMPUTE_MAXS);
+            asmClass.accept(cw);
+            var bytes = cw.toByteArray();
+            Unsafe.defineClass(cpwClassName, bytes, 0, bytes.length, cl, domain);
+        } catch (IOException e) {
+            return e;
+        }
+        return null;
+    }
+
+    @SuppressWarnings({"unused", "unchecked"})
+    public static void onInvoke$BootstrapLauncher(String[] args, ModuleClassLoader moduleCl) {
+        try {
+            Class<ApplicationBootstrap> arclightBootClz = (Class<ApplicationBootstrap>) moduleCl.loadClass("io.izzel.arclight.boot.application.ApplicationBootstrap");
+            Object instance = arclightBootClz.getConstructor().newInstance();
+            arclightBootClz.getMethod("accept", String[].class).invoke(instance, (Object) args);
+        } catch (ReflectiveOperationException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/arclight-forge/src/main/java/io/izzel/arclight/boot/application/BootstrapTransformer.java
+++ b/arclight-forge/src/main/java/io/izzel/arclight/boot/application/BootstrapTransformer.java
@@ -1,102 +1,22 @@
 package io.izzel.arclight.boot.application;
 
 import cpw.mods.cl.ModuleClassLoader;
-import io.izzel.arclight.api.Unsafe;
 import org.objectweb.asm.*;
 import org.objectweb.asm.tree.*;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.security.ProtectionDomain;
-import java.util.Map;
-import java.util.function.BiFunction;
 
-public class BootstrapTransformer {
-    private static final Map<String, BiFunction<ClassLoader, ProtectionDomain, Exception>> SUPPORTED = Map.of(
-            "cpw.mods.bootstraplauncher.BootstrapLauncher",
-            BootstrapTransformer::transformBootstrapLauncher
-    );
+/*
+ * The implementation is affected by BootstrapLauncher and ModLauncher
+ * Be sure to check for updates.
+ */
+public class BootstrapTransformer extends ClassLoader {
 
-    public static Class<?> loadTransform(String className, ClassLoader cl, ProtectionDomain domain) throws Exception {
-        if (!SUPPORTED.containsKey(className)) {
-            throw new UnsupportedOperationException("Transformation for "+className+" is not supported");
-        }
-        var ex = SUPPORTED.get(className).apply(cl, domain);
-        if (ex != null) throw ex;
-        return cl.loadClass(className);
-    }
+    private static final String cpwClass = "cpw.mods.bootstraplauncher.BootstrapLauncher";
 
-    /*
-     * Previous implementation of BootstrapLauncher relies on the order of ServiceLoader.load().stream()
-     * where the ApplicationBootstrap will be ahead of modlauncher, which is an UB related to module name.
-     * Modify BootstrapLauncher to use ApplicationBootstrap directly so a change in module name won't
-     * affect launch process.
-     */
-    public static Exception transformBootstrapLauncher(ClassLoader cl, ProtectionDomain domain) {
-        final var cpwClassName = "cpw.mods.bootstraplauncher.BootstrapLauncher";
-        final var cpwClassFile = "cpw/mods/bootstraplauncher/BootstrapLauncher.class";
-        System.out.println("Transforming " + cpwClassName);
-        try(var inputStream = cl.getResourceAsStream(cpwClassFile)) {
-            if (inputStream == null) {
-                return new IOException("getResourceAsStream can't read BootstrapLauncher.class");
-            }
-            var asmClass = new ClassNode();
-            new ClassReader(inputStream).accept(asmClass, 0);
-            // Find main(String[])
-            MethodNode asmMain = null;
-            for (var asmMethod : asmClass.methods) {
-                if ("main".equals(asmMethod.name)) {
-                    asmMain = asmMethod;
-                    break;
-                }
-            }
-            if (asmMain == null) {
-                return new NullPointerException("Cannot find main(String[]) in BootstrapLauncher");
-            }
-            // Apply transformation
-            var insns = asmMain.instructions;
-            var injected = false;
-            for (int i = 0; i < insns.size(); i++) {
-                if (insns.get(i) instanceof MethodInsnNode invoke) {
-                    if ("java/util/function/Consumer".equals(invoke.owner)
-                            && "accept".equals(invoke.name)) {
-                        // Raw: [SERVICE].accept(args);
-                        // Modified: ((Consumer)new ApplicationBootstrap()).accept(args);
-                        var createArclightBoot = new InsnList();
-                        {
-                            var popArgsThenService = new InsnNode(Opcodes.POP2);
-                            var aloadArgs = new VarInsnNode(Opcodes.ALOAD, 0);
-                            var aloadModuleCl = new VarInsnNode(Opcodes.ALOAD, 15);
-                            var onInvoke = new MethodInsnNode(
-                                    Opcodes.INVOKESTATIC,
-                                    "io/izzel/arclight/boot/application/BootstrapTransformer",
-                                    "onInvoke$BootstrapLauncher",
-                                    "([Ljava/lang/String;Lcpw/mods/cl/ModuleClassLoader;)V"
-                            );
-                            createArclightBoot.add(popArgsThenService);
-                            createArclightBoot.add(aloadArgs);
-                            createArclightBoot.add(aloadModuleCl);
-                            createArclightBoot.add(onInvoke);
-                        }
-                        insns.insert(invoke, createArclightBoot);
-                        insns.remove(invoke);
-                        injected = true;
-                        break;
-                    }
-                }
-            }
-            if (!injected) {
-                return new Exception("BootstrapTransformer failed to transform BootstrapLauncher: Consumer.accept(String[]) not found");
-            }
-            // Save and define transformed class
-            var cw = new ClassWriter(ClassWriter.COMPUTE_MAXS);
-            asmClass.accept(cw);
-            var bytes = cw.toByteArray();
-            Unsafe.defineClass(cpwClassName, bytes, 0, bytes.length, cl, domain);
-        } catch (IOException e) {
-            return e;
-        }
-        return null;
-    }
+    private final ProtectionDomain domain = getClass().getProtectionDomain();
 
     @SuppressWarnings({"unused", "unchecked"})
     public static void onInvoke$BootstrapLauncher(String[] args, ModuleClassLoader moduleCl) {
@@ -107,5 +27,147 @@ public class BootstrapTransformer {
         } catch (ReflectiveOperationException e) {
             throw new RuntimeException(e);
         }
+    }
+
+    public BootstrapTransformer(ClassLoader appClassLoader) {
+        super("arclight_bootstrap", appClassLoader);
+    }
+
+    /*
+     * The class to transform can be resolved by AppClassLoader.
+     * We have to break the delegation model to intercept class loading.
+     */
+    @Override
+    protected Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
+        synchronized (getClassLoadingLock(name)) {
+            Class<?> c = findLoadedClass(name);
+            if (c != null) {
+                return c;
+            }
+
+            // The class is not loaded. Are we going to intercept?
+            // The inner classes and the outer class should be loaded
+            // in the same ClassLoader to avoid inter-module access issues.
+            if (!name.contains(cpwClass)) {
+                // Delegate to parent.
+                // parent.loadClass is inaccessible from here.
+                // This ClassLoader will only load the launcher
+                // and then a new ClassLoader, whose parent is
+                // platform ClassLoader (null), will load the game.
+                return super.loadClass(name, resolve);
+            }
+
+            Class<?> clz;
+            try {
+                clz = loadTransform(name);
+            } catch (IOException e) {
+                e.printStackTrace();
+                throw new ClassNotFoundException("Unexpected exception loading " + name);
+            }
+
+            if (resolve) {
+                resolveClass(clz);
+            }
+            return clz;
+        }
+    }
+
+    /*
+     * findClass() is invoked when parent (in this case AppClassLoader)
+     * cannot find the corresponding class. In this case we can't find either.
+     */
+    @Override
+    protected Class<?> findClass(String name) throws ClassNotFoundException {
+        throw new ClassNotFoundException(name);
+    }
+
+    public Class<?> loadTransform(String className) throws IOException {
+        if (className.equals(cpwClass)) {
+            var file = cpwClass.replace('.', '/').concat(".class");
+            try (var inputStream = getResourceAsStream(file)) {
+                if (inputStream == null) {
+                    throw new RuntimeException("getResourceAsStream can't read BootstrapLauncher.class");
+                }
+                var transformed = transformBootstrapLauncher(inputStream);
+                return defineClass(cpwClass, transformed, 0, transformed.length, domain);
+            }
+        } else if (className.contains(cpwClass)) {
+            var file = className.replace('.', '/').concat(".class");
+            try (var inputStream = getResourceAsStream(file)) {
+                if (inputStream == null) {
+                    throw new RuntimeException("getResourceAsStream can't read "+file.substring(file.lastIndexOf('/')));
+                }
+                var bytes = inputStream.readAllBytes();
+                return defineClass(className, bytes, 0, bytes.length, domain);
+            }
+        }
+        throw new UnsupportedOperationException("Transformation for " + className + " is not supported");
+    }
+
+    /*
+     * Previous implementation of BootstrapLauncher relies on the order of ServiceLoader.load().stream()
+     * where the ApplicationBootstrap will be ahead of modlauncher, which is an UB related to module name.
+     * Modify BootstrapLauncher to use ApplicationBootstrap directly so a change in module name won't
+     * affect launch process.
+     */
+    public byte[] transformBootstrapLauncher(InputStream inputStream) throws IOException {
+        System.out.println("Transforming cpw.mods.bootstraplauncher.BootstrapLauncher");
+        var asmClass = new ClassNode();
+        new ClassReader(inputStream).accept(asmClass, 0);
+
+        // Find main(String[])
+        MethodNode asmMain = null;
+        for (var asmMethod : asmClass.methods) {
+            if ("main".equals(asmMethod.name)) {
+                asmMain = asmMethod;
+                break;
+            }
+        }
+        if (asmMain == null) {
+            throw new RuntimeException("Cannot find main(String[]) in BootstrapLauncher");
+        }
+
+        // Find Consumer.accept(...)
+        var insns = asmMain.instructions;
+        MethodInsnNode injectionPoint = null;
+        for (int i = 0; i < insns.size(); i++) {
+            if (insns.get(i) instanceof MethodInsnNode invoke) {
+                if ("java/util/function/Consumer".equals(invoke.owner)
+                        && "accept".equals(invoke.name)) {
+                    injectionPoint = invoke;
+                    break;
+                }
+            }
+        }
+        if (injectionPoint == null) {
+            throw new RuntimeException("BootstrapTransformer failed to transform BootstrapLauncher: Consumer.accept(String[]) not found");
+        }
+
+        // Apply transformation
+        // Raw: [SERVICE].accept(args);
+        // Modified: BootstrapTransformer.onInvoke$BootstrapLauncher(...);
+        var createArclightBoot = new InsnList();
+        {
+            var popArgsThenService = new InsnNode(Opcodes.POP2);
+            var aloadArgs = new VarInsnNode(Opcodes.ALOAD, 0);
+            var aloadModuleCl = new VarInsnNode(Opcodes.ALOAD, 15);
+            var onInvoke = new MethodInsnNode(
+                    Opcodes.INVOKESTATIC,
+                    "io/izzel/arclight/boot/application/BootstrapTransformer",
+                    "onInvoke$BootstrapLauncher",
+                    "([Ljava/lang/String;Lcpw/mods/cl/ModuleClassLoader;)V"
+            );
+            createArclightBoot.add(popArgsThenService);
+            createArclightBoot.add(aloadArgs);
+            createArclightBoot.add(aloadModuleCl);
+            createArclightBoot.add(onInvoke);
+        }
+        insns.insert(injectionPoint, createArclightBoot);
+        insns.remove(injectionPoint);
+
+        // Save transformed class
+        var cw = new ClassWriter(ClassWriter.COMPUTE_MAXS);
+        asmClass.accept(cw);
+        return cw.toByteArray();
     }
 }

--- a/arclight-forge/src/main/java/io/izzel/arclight/boot/application/Main_Forge.java
+++ b/arclight-forge/src/main/java/io/izzel/arclight/boot/application/Main_Forge.java
@@ -24,7 +24,8 @@ public class Main_Forge {
             // The manifest data will be unavailable for further use, stop here
             verifyManifest();
             Map.Entry<String, List<String>> install = forgeInstall();
-            var cl = Class.forName(install.getKey());
+            var clazz = Main_Forge.class;
+            var cl = BootstrapTransformer.loadTransform(install.getKey(), clazz.getClassLoader(), clazz.getProtectionDomain());
             var method = cl.getMethod("main", String[].class);
             var target = Stream.concat(install.getValue().stream(), Arrays.stream(args)).toArray(String[]::new);
             method.invoke(null, (Object) target);
@@ -39,13 +40,13 @@ public class Main_Forge {
         var location = Main_Forge.class.getProtectionDomain().getCodeSource().getLocation();
         try(JarFile baseArchive = new JarFile(new File(location.toURI()))) {
             var mf = baseArchive.getManifest();
-            if (mf == null || mf.getEntries().isEmpty()) {
+            if (mf == null || mf.getMainAttributes().isEmpty()) {
                 System.err.println("Failed to verify completeness for Arclight installer.");
                 System.err.println("The manifest data is corrupted, is the jar file modified?");
                 System.err.println("Cannot proceed, Arclight will exit");
+                throw new IOException("The installer jar file is corrupted");
             }
         }
-        throw new IOException("The installer jar file is corrupted");
     }
 
     @SuppressWarnings("unchecked")

--- a/arclight-forge/src/main/java/io/izzel/arclight/boot/application/Main_Forge.java
+++ b/arclight-forge/src/main/java/io/izzel/arclight/boot/application/Main_Forge.java
@@ -1,7 +1,10 @@
 package io.izzel.arclight.boot.application;
 
+import java.io.File;
+import java.io.IOException;
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodType;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.nio.file.Files;
@@ -10,12 +13,16 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.jar.JarFile;
 import java.util.stream.Stream;
 
 public class Main_Forge {
 
     public static void main(String[] args) throws Throwable {
         try {
+            // Modifying the installer with a file archiver will corrupt the jar file
+            // The manifest data will be unavailable for further use, stop here
+            verifyManifest();
             Map.Entry<String, List<String>> install = forgeInstall();
             var cl = Class.forName(install.getKey());
             var method = cl.getMethod("main", String[].class);
@@ -26,6 +33,19 @@ public class Main_Forge {
             System.err.println("Fail to launch Arclight.");
             System.exit(-1);
         }
+    }
+
+    private static void verifyManifest() throws IOException, URISyntaxException {
+        var location = Main_Forge.class.getProtectionDomain().getCodeSource().getLocation();
+        try(JarFile baseArchive = new JarFile(new File(location.toURI()))) {
+            var mf = baseArchive.getManifest();
+            if (mf == null || mf.getEntries().isEmpty()) {
+                System.err.println("Failed to verify completeness for Arclight installer.");
+                System.err.println("The manifest data is corrupted, is the jar file modified?");
+                System.err.println("Cannot proceed, Arclight will exit");
+            }
+        }
+        throw new IOException("The installer jar file is corrupted");
     }
 
     @SuppressWarnings("unchecked")

--- a/arclight-forge/src/main/java/io/izzel/arclight/boot/application/Main_Forge.java
+++ b/arclight-forge/src/main/java/io/izzel/arclight/boot/application/Main_Forge.java
@@ -1,5 +1,7 @@
 package io.izzel.arclight.boot.application;
 
+import cpw.mods.cl.ModuleClassLoader;
+
 import java.io.File;
 import java.io.IOException;
 import java.lang.invoke.MethodHandles;
@@ -24,9 +26,9 @@ public class Main_Forge {
             // The manifest data will be unavailable for further use, stop here
             verifyManifest();
             Map.Entry<String, List<String>> install = forgeInstall();
-            var clazz = Main_Forge.class;
-            var cl = BootstrapTransformer.loadTransform(install.getKey(), clazz.getClassLoader(), clazz.getProtectionDomain());
-            var method = cl.getMethod("main", String[].class);
+            var cl = new BootstrapTransformer(Main_Forge.class.getClassLoader());
+            var clazz = cl.loadClass(install.getKey(), true);
+            var method = clazz.getMethod("main", String[].class);
             var target = Stream.concat(install.getValue().stream(), Arrays.stream(args)).toArray(String[]::new);
             method.invoke(null, (Object) target);
         } catch (Exception e) {


### PR DESCRIPTION
In the latest release of Trials, modifying the forge installer jar file may corrupt the manifest data, exposing a potential issue of relying on an undefined order of ServiceLoader.load(...).stream() between different modules in the same layer. 
The issue will cause a conditional crash that depends on the archive file name when the installer is modified externally. The module name will also be related to the file name.

In this PR:
1. The manifest data is checked in advance and if it's corrupted (in this case nothing will be read), the installer crashes with a reminder.
2. The service loading mechanism is replaced with reflection to ensure proper working.