### PR TITLE
ATM10 compatibility

### DIFF
--- a/arclight-common/src/main/java/io/izzel/arclight/common/bridge/bukkit/MaterialBridge.java
+++ b/arclight-common/src/main/java/io/izzel/arclight/common/bridge/bukkit/MaterialBridge.java
@@ -16,11 +16,13 @@ import java.util.function.Function;
 
 public interface MaterialBridge {
 
-    void bridge$setupBlock(ResourceLocation key, Block block, MaterialPropertySpec spec);
+    ResourceLocation AIR = ResourceLocation.parse("air");
+
+    void bridge$setupBlock(ResourceLocation key, MaterialPropertySpec spec);
 
     void bridge$setupVanillaBlock(MaterialPropertySpec spec);
 
-    void bridge$setupItem(ResourceLocation key, Item item, MaterialPropertySpec spec);
+    void bridge$setupItem(ResourceLocation key, MaterialPropertySpec spec);
 
     void bridge$setBlock();
 

--- a/arclight-common/src/main/java/io/izzel/arclight/common/mixin/bukkit/MaterialMixin.java
+++ b/arclight-common/src/main/java/io/izzel/arclight/common/mixin/bukkit/MaterialMixin.java
@@ -88,6 +88,7 @@ public abstract class MaterialMixin implements MaterialBridge {
 
     private MaterialPropertySpec.MaterialType arclight$type = MaterialPropertySpec.MaterialType.VANILLA;
     private MaterialPropertySpec arclight$spec;
+    private ResourceLocation arclight$location;
     private boolean arclight$block = false, arclight$item = false;
 
     @Override
@@ -117,6 +118,9 @@ public abstract class MaterialMixin implements MaterialBridge {
     @Inject(method = "isEdible", cancellable = true, at = @At("HEAD"))
     private void arclight$isEdible(CallbackInfoReturnable<Boolean> cir) {
         if (arclight$spec != null) {
+            if (!arclight$spec.isPresent) {
+                arclight$setupCommon();
+            }
             cir.setReturnValue(arclight$spec.edible);
         }
     }
@@ -124,6 +128,9 @@ public abstract class MaterialMixin implements MaterialBridge {
     @Inject(method = "isRecord", cancellable = true, at = @At("HEAD"))
     private void arclight$isRecord(CallbackInfoReturnable<Boolean> cir) {
         if (arclight$spec != null) {
+            if (!arclight$spec.isPresent) {
+                arclight$setupCommon();
+            }
             cir.setReturnValue(arclight$spec.record);
         }
     }
@@ -131,6 +138,9 @@ public abstract class MaterialMixin implements MaterialBridge {
     @Inject(method = "isSolid", cancellable = true, at = @At("HEAD"))
     private void arclight$isSolid(CallbackInfoReturnable<Boolean> cir) {
         if (arclight$spec != null) {
+            if (!arclight$spec.isPresent) {
+                arclight$setupCommon();
+            }
             cir.setReturnValue(arclight$spec.solid);
         }
     }
@@ -138,6 +148,9 @@ public abstract class MaterialMixin implements MaterialBridge {
     @Inject(method = "isAir", cancellable = true, at = @At("HEAD"))
     private void arclight$isAir(CallbackInfoReturnable<Boolean> cir) {
         if (arclight$spec != null) {
+            if (!arclight$spec.isPresent) {
+                arclight$setupCommon();
+            }
             cir.setReturnValue(arclight$spec.air);
         }
     }
@@ -145,6 +158,9 @@ public abstract class MaterialMixin implements MaterialBridge {
     @Inject(method = "isTransparent", cancellable = true, at = @At("HEAD"))
     private void arclight$isTransparent(CallbackInfoReturnable<Boolean> cir) {
         if (arclight$spec != null) {
+            if (!arclight$spec.isPresent) {
+                arclight$setupCommon();
+            }
             cir.setReturnValue(arclight$spec.transparent);
         }
     }
@@ -152,6 +168,9 @@ public abstract class MaterialMixin implements MaterialBridge {
     @Inject(method = "isFlammable", cancellable = true, at = @At("HEAD"))
     private void arclight$isFlammable(CallbackInfoReturnable<Boolean> cir) {
         if (arclight$spec != null) {
+            if (!arclight$spec.isPresent) {
+                arclight$setupCommon();
+            }
             cir.setReturnValue(arclight$spec.flammable);
         }
     }
@@ -159,6 +178,9 @@ public abstract class MaterialMixin implements MaterialBridge {
     @Inject(method = "isBurnable", cancellable = true, at = @At("HEAD"))
     private void arclight$isBurnable(CallbackInfoReturnable<Boolean> cir) {
         if (arclight$spec != null) {
+            if (!arclight$spec.isPresent) {
+                arclight$setupCommon();
+            }
             cir.setReturnValue(arclight$spec.burnable);
         }
     }
@@ -166,6 +188,9 @@ public abstract class MaterialMixin implements MaterialBridge {
     @Inject(method = "isFuel", cancellable = true, at = @At("HEAD"))
     private void arclight$isFuel(CallbackInfoReturnable<Boolean> cir) {
         if (arclight$spec != null) {
+            if (!arclight$spec.isPresent) {
+                arclight$setupCommon();
+            }
             cir.setReturnValue(arclight$spec.fuel);
         }
     }
@@ -173,6 +198,9 @@ public abstract class MaterialMixin implements MaterialBridge {
     @Inject(method = "isOccluding", cancellable = true, at = @At("HEAD"))
     private void arclight$isOccluding(CallbackInfoReturnable<Boolean> cir) {
         if (arclight$spec != null) {
+            if (!arclight$spec.isPresent) {
+                arclight$setupCommon();
+            }
             cir.setReturnValue(arclight$spec.occluding);
         }
     }
@@ -180,6 +208,9 @@ public abstract class MaterialMixin implements MaterialBridge {
     @Inject(method = "hasGravity", cancellable = true, at = @At("HEAD"))
     private void arclight$hasGravity(CallbackInfoReturnable<Boolean> cir) {
         if (arclight$spec != null) {
+            if (!arclight$spec.isPresent) {
+                arclight$setupCommon();
+            }
             cir.setReturnValue(arclight$spec.gravity);
         }
     }
@@ -187,6 +218,9 @@ public abstract class MaterialMixin implements MaterialBridge {
     @Inject(method = "isInteractable", cancellable = true, at = @At("HEAD"))
     private void arclight$isInteractable(CallbackInfoReturnable<Boolean> cir) {
         if (arclight$spec != null) {
+            if (!arclight$spec.isPresent) {
+                arclight$setupCommon();
+            }
             cir.setReturnValue(arclight$spec.interactable);
         }
     }
@@ -194,6 +228,9 @@ public abstract class MaterialMixin implements MaterialBridge {
     @Inject(method = "getHardness", cancellable = true, at = @At("HEAD"))
     private void arclight$getHardness(CallbackInfoReturnable<Float> cir) {
         if (arclight$spec != null) {
+            if (!arclight$spec.isPresent) {
+                arclight$setupCommon();
+            }
             cir.setReturnValue(arclight$spec.hardness);
         }
     }
@@ -201,6 +238,9 @@ public abstract class MaterialMixin implements MaterialBridge {
     @Inject(method = "getBlastResistance", cancellable = true, at = @At("HEAD"))
     private void arclight$getBlastResistance(CallbackInfoReturnable<Float> cir) {
         if (arclight$spec != null) {
+            if (!arclight$spec.isPresent) {
+                arclight$setupCommon();
+            }
             cir.setReturnValue(arclight$spec.blastResistance);
         }
     }
@@ -208,21 +248,34 @@ public abstract class MaterialMixin implements MaterialBridge {
     @Inject(method = "getMaxStackSize", cancellable = true, at = @At("HEAD"))
     private void arclight$getMaxStackSize(CallbackInfoReturnable<Integer> cir) {
         if (arclight$spec != null) {
+            if (!arclight$spec.isPresent) {
+                arclight$setupCommon();
+            }
             cir.setReturnValue(arclight$spec.maxStack);
         }
     }
 
     @Inject(method = "getMaxDurability", cancellable = true, at = @At("HEAD"))
     private void arclight$getMaxDurability(CallbackInfoReturnable<Short> cir) {
-        if (arclight$spec != null && arclight$spec.maxDurability != null) {
-            cir.setReturnValue(arclight$spec.maxDurability.shortValue());
+        if (arclight$spec != null) {
+            if (!arclight$spec.isPresent) {
+                arclight$setupCommon();
+            }
+            if (arclight$spec.maxDurability != null) {
+                cir.setReturnValue(arclight$spec.maxDurability.shortValue());
+            }
         }
     }
 
     @Inject(method = "getCraftingRemainingItem", cancellable = true, at = @At("HEAD"))
     private void arclight$getCraftingRemainingItem(CallbackInfoReturnable<Material> cir) {
-        if (arclight$spec != null && arclight$spec.craftingRemainingItem != null) {
-            cir.setReturnValue(CraftMagicNumbers.getMaterial(BuiltInRegistries.ITEM.get(ResourceLocation.parse(arclight$spec.craftingRemainingItem))));
+        if (arclight$spec != null) {
+            if (!arclight$spec.isPresent) {
+                arclight$setupCommon();
+            }
+            if (arclight$spec.craftingRemainingItem != null) {
+                cir.setReturnValue(CraftMagicNumbers.getMaterial(BuiltInRegistries.ITEM.get(ResourceLocation.parse(arclight$spec.craftingRemainingItem))));
+            }
         }
     }
 
@@ -261,27 +314,27 @@ public abstract class MaterialMixin implements MaterialBridge {
     }
 
     @Override
-    public void bridge$setupBlock(ResourceLocation key, Block block, MaterialPropertySpec spec) {
+    public void bridge$setupBlock(ResourceLocation key, MaterialPropertySpec spec) {
         this.arclight$spec = spec.clone();
         arclight$type = MaterialPropertySpec.MaterialType.FORGE;
         arclight$block = true;
-        arclight$setupCommon(key, block, block.asItem());
+        arclight$setupCommonLazy(key);
     }
 
     @Override
     public void bridge$setupVanillaBlock(MaterialPropertySpec spec) {
-        if (spec != MaterialPropertySpec.EMPTY) {
+        if (spec.isPresent) {
             this.arclight$spec = spec.clone();
             this.setupBlockStateFunc();
         }
     }
 
     @Override
-    public void bridge$setupItem(ResourceLocation key, Item item, MaterialPropertySpec spec) {
+    public void bridge$setupItem(ResourceLocation key, MaterialPropertySpec spec) {
         this.arclight$spec = spec.clone();
         arclight$type = MaterialPropertySpec.MaterialType.FORGE;
         arclight$item = true;
-        arclight$setupCommon(key, null, item);
+        arclight$setupCommonLazy(key);
     }
 
     @Override
@@ -291,7 +344,7 @@ public abstract class MaterialMixin implements MaterialBridge {
     }
 
     @SuppressWarnings("unchecked")
-    private void arclight$setupCommon(ResourceLocation key, Block block, Item item) {
+    private void arclight$setupCommonLazy(ResourceLocation key) {
         this.key = CraftNamespacedKey.fromMinecraft(key);
         if (arclight$spec.materialDataClass != null) {
             try {
@@ -305,6 +358,39 @@ public abstract class MaterialMixin implements MaterialBridge {
                 ArclightServer.LOGGER.warn(e);
             }
         }
+        arclight$location = key;
+    }
+
+    private void arclight$setupCommon() {
+        Block block = BuiltInRegistries.BLOCK.get(arclight$location);
+        Item item = BuiltInRegistries.ITEM.get(arclight$location);
+
+        // Block properties
+        if (arclight$location.equals(MaterialBridge.AIR) || block != Blocks.AIR) {
+            if (arclight$spec.solid == null) {
+                arclight$spec.solid = block.defaultBlockState().canOcclude();
+            }
+            if (arclight$spec.air == null) {
+                arclight$spec.air = block.defaultBlockState().isAir();
+            }
+            if (arclight$spec.transparent == null) {
+                arclight$spec.transparent = block.defaultBlockState().useShapeForLightOcclusion();
+            }
+            if (arclight$spec.flammable == null) {
+                arclight$spec.flammable = ((FireBlockBridge) Blocks.FIRE).bridge$canBurn(block);
+            }
+            if (arclight$spec.burnable == null) {
+                arclight$spec.burnable = ((FireBlockBridge) Blocks.FIRE).bridge$canBurn(block);
+            }
+            if (arclight$spec.hardness == null) {
+                arclight$spec.hardness = block.defaultBlockState().destroySpeed;
+            }
+            if (arclight$spec.blastResistance == null) {
+                arclight$spec.blastResistance = block.getExplosionResistance();
+            }
+        }
+
+        // Item properties
         if (arclight$spec.maxStack == null) {
             arclight$spec.maxStack = bridge$forge$getMaxStackSize(item);
         }
@@ -317,23 +403,8 @@ public abstract class MaterialMixin implements MaterialBridge {
         if (arclight$spec.record == null) {
             arclight$spec.record = false;
         }
-        if (arclight$spec.solid == null) {
-            arclight$spec.solid = block != null && block.defaultBlockState().canOcclude();
-        }
-        if (arclight$spec.air == null) {
-            arclight$spec.air = block != null && block.defaultBlockState().isAir();
-        }
-        if (arclight$spec.transparent == null) {
-            arclight$spec.transparent = block != null && block.defaultBlockState().useShapeForLightOcclusion();
-        }
-        if (arclight$spec.flammable == null) {
-            arclight$spec.flammable = block != null && ((FireBlockBridge) Blocks.FIRE).bridge$canBurn(block);
-        }
-        if (arclight$spec.burnable == null) {
-            arclight$spec.burnable = block != null && ((FireBlockBridge) Blocks.FIRE).bridge$canBurn(block);
-        }
         if (arclight$spec.fuel == null) {
-            arclight$spec.fuel = item != null && bridge$forge$getBurnTime(item) > 0;
+            arclight$spec.fuel = bridge$forge$getBurnTime(item) > 0;
         }
         if (arclight$spec.occluding == null) {
             arclight$spec.occluding = arclight$spec.solid;
@@ -344,19 +415,15 @@ public abstract class MaterialMixin implements MaterialBridge {
         if (arclight$spec.interactable == null) {
             arclight$spec.interactable = true;
         }
-        if (arclight$spec.hardness == null) {
-            arclight$spec.hardness = block != null ? block.defaultBlockState().destroySpeed : 0;
-        }
-        if (arclight$spec.blastResistance == null) {
-            arclight$spec.blastResistance = block != null ? block.getExplosionResistance() : 0;
-        }
         if (arclight$spec.craftingRemainingItem == null) {
             // noinspection deprecation
-            arclight$spec.craftingRemainingItem = item != null && item.hasCraftingRemainingItem() ? bridge$getCraftRemainingItem(item).toString() : null;
+            arclight$spec.craftingRemainingItem = item.hasCraftingRemainingItem() ? bridge$getCraftRemainingItem(item).toString() : null;
         }
         if (arclight$spec.itemMetaType == null) {
             arclight$spec.itemMetaType = "UNSPECIFIC";
         }
+        arclight$spec.present();
+
         BiFunction<Material, CraftMetaItem, ItemMeta> function = TYPES.get(arclight$spec.itemMetaType);
         if (function != null) {
             this.arclight$metaFunc = meta -> function.apply((Material) (Object) this, meta);

--- a/arclight-common/src/main/java/io/izzel/arclight/common/mixin/core/network/ServerGamePacketListenerImplMixin.java
+++ b/arclight-common/src/main/java/io/izzel/arclight/common/mixin/core/network/ServerGamePacketListenerImplMixin.java
@@ -285,14 +285,6 @@ public abstract class ServerGamePacketListenerImplMixin extends ServerCommonPack
             if (entity != this.player && entity.getControllingPassenger() == this.player && entity == this.lastVehicle) {
                 ServerLevel worldserver = this.player.serverLevel();
 
-                // CraftBukkit - store current player position
-                double prevX = player.getX();
-                double prevY = player.getY();
-                double prevZ = player.getZ();
-                float prevYaw = player.getYRot();
-                float prevPitch = player.getXRot();
-                // CraftBukkit end
-
                 double d0 = entity.getX();
                 double d2 = entity.getY();
                 double d3 = entity.getZ();
@@ -305,6 +297,20 @@ public abstract class ServerGamePacketListenerImplMixin extends ServerCommonPack
                 double d8 = d5 - this.vehicleFirstGoodY;
                 double d9 = d6 - this.vehicleFirstGoodZ;
                 double d10 = entity.getDeltaMovement().lengthSqr();
+
+                // Down shift to support ServerCore injecting into lengthSqr.
+                // They are capturing the above 11 fp numbers (d0-d9, f, f2).
+                // mixin can't distinguish between ours and original ones.
+                // Perhaps due to we have 2 floats that's similar to above.
+                // Mixin plz, allow overlapping possible captures!
+                // CraftBukkit - store current player position
+                double prevX = player.getX();
+                double prevY = player.getY();
+                double prevZ = player.getZ();
+                float prevYaw = player.getYRot();
+                float prevPitch = player.getXRot();
+                // CraftBukkit end
+
                 double d11 = d7 * d7 + d8 * d8 + d9 * d9;
                 this.allowedPlayerTicks += (int) (System.currentTimeMillis() / 50L - this.lastTick);
                 this.allowedPlayerTicks = Math.max(this.allowedPlayerTicks, 1);
@@ -478,6 +484,13 @@ public abstract class ServerGamePacketListenerImplMixin extends ServerCommonPack
         DecorationOps.callsite().invoke(instance, i, handStack);
     }
 
+    // Support imfast changing moved wrongly threshold in ATM10
+    @SuppressWarnings("SameParameterValue")
+    private double arclight$selectMovedWronglyThreshold(double raw) {
+        double spigot = org.spigotmc.SpigotConfig.movedWronglyThreshold;
+        return raw != 0.0625 ? Math.max(raw, spigot) : spigot;
+    }
+
     /**
      * @author IzzelAliz
      * @reason
@@ -506,6 +519,21 @@ public abstract class ServerGamePacketListenerImplMixin extends ServerCommonPack
                         this.player.serverLevel().getChunkSource().move(this.player);
                         this.allowedPlayerTicks = 20; // CraftBukkit
                     } else {
+                        double d3 = this.player.getX();
+                        double d4 = this.player.getY();
+                        double d5 = this.player.getZ();
+                        // This is not in ServerGamePacketListenerImpl.
+                        // It is unused, then why it's here?
+                        // double d6 = this.player.getY();
+                        double d7 = d0 - this.firstGoodX;
+                        double d8 = d1 - this.firstGoodY;
+                        double d9 = d2 - this.firstGoodZ;
+                        double d10 = this.player.getDeltaMovement().lengthSqr();
+                        double d11 = d7 * d7 + d8 * d8 + d9 * d9;
+
+                        // Down shift to support ServerCore injecting into lengthSqr.
+                        // They are capturing the above 8 fp numbers (d0-d5, f, f1).
+                        // mixin can't distinguish between ours and original ones.
                         // CraftBukkit - Make sure the move is valid but then reset it for plugins to modify
                         double prevX = player.getX();
                         double prevY = player.getY();
@@ -513,15 +541,8 @@ public abstract class ServerGamePacketListenerImplMixin extends ServerCommonPack
                         float prevYaw = player.getYRot();
                         float prevPitch = player.getXRot();
                         // CraftBukkit end
-                        double d3 = this.player.getX();
-                        double d4 = this.player.getY();
-                        double d5 = this.player.getZ();
-                        double d6 = this.player.getY();
-                        double d7 = d0 - this.firstGoodX;
-                        double d8 = d1 - this.firstGoodY;
-                        double d9 = d2 - this.firstGoodZ;
-                        double d10 = this.player.getDeltaMovement().lengthSqr();
-                        double d11 = d7 * d7 + d8 * d8 + d9 * d9;
+                        // Below is isSleeping() which can be another injection point.
+                        // Mixin plz, allow overlapping possible captures!
 
                         if (this.player.isSleeping()) {
                             if (d11 > 1.0D) {
@@ -593,7 +614,8 @@ public abstract class ServerGamePacketListenerImplMixin extends ServerCommonPack
                             d11 = d7 * d7 + d8 * d8 + d9 * d9;
                             boolean flag1 = false;
 
-                            if (!this.player.isChangingDimension() && d11 > org.spigotmc.SpigotConfig.movedWronglyThreshold && !this.player.isSleeping() && !this.player.gameMode.isCreative() && this.player.gameMode.getGameModeForPlayer() != GameType.SPECTATOR) { // Spigot
+                            // Support imfast changing moved wrongly threshold constant (0.0625) in ATM10
+                            if (!this.player.isChangingDimension() && d11 > arclight$selectMovedWronglyThreshold(0.0625) && !this.player.isSleeping() && !this.player.gameMode.isCreative() && this.player.gameMode.getGameModeForPlayer() != GameType.SPECTATOR) { // Spigot
                                 flag1 = true;
                                 LOGGER.warn("{} moved wrongly!", this.player.getName().getString());
                             }

--- a/arclight-common/src/main/java/io/izzel/arclight/common/mod/server/BukkitRegistry.java
+++ b/arclight-common/src/main/java/io/izzel/arclight/common/mod/server/BukkitRegistry.java
@@ -9,6 +9,7 @@ import io.izzel.arclight.api.Unsafe;
 import io.izzel.arclight.common.bridge.bukkit.EntityTypeBridge;
 import io.izzel.arclight.common.bridge.bukkit.MaterialBridge;
 import io.izzel.arclight.common.bridge.bukkit.SimpleRegistryBridge;
+import io.izzel.arclight.common.mixin.core.network.ServerGamePacketListenerImplMixin;
 import io.izzel.arclight.common.mod.server.entity.EntityClassLookup;
 import io.izzel.arclight.common.mod.util.ResourceLocationUtil;
 import io.izzel.arclight.i18n.ArclightConfig;
@@ -346,7 +347,7 @@ public class BukkitRegistry {
             Material material = BY_NAME.get(name);
             if (material == null) {
                 material = EnumHelper.makeEnum(Material.class, name, i, MAT_CTOR, ImmutableList.of(i));
-                ((MaterialBridge) (Object) material).bridge$setupBlock(location, block, matSpec(location));
+                ((MaterialBridge) (Object) material).bridge$setupBlock(location, matSpec(location));
                 BY_NAME.put(name, material);
                 i++;
                 blocks++;
@@ -370,7 +371,7 @@ public class BukkitRegistry {
             Material material = BY_NAME.get(name);
             if (material == null) {
                 material = EnumHelper.makeEnum(Material.class, name, i, MAT_CTOR, ImmutableList.of(i));
-                ((MaterialBridge) (Object) material).bridge$setupItem(location, item, matSpec(location));
+                ((MaterialBridge) (Object) material).bridge$setupItem(location, matSpec(location));
                 BY_NAME.put(name, material);
                 i++;
                 items++;

--- a/i18n-config/src/main/java/io/izzel/arclight/i18n/conf/MaterialPropertySpec.java
+++ b/i18n-config/src/main/java/io/izzel/arclight/i18n/conf/MaterialPropertySpec.java
@@ -6,7 +6,7 @@ import ninja.leaping.configurate.objectmapping.serialize.ConfigSerializable;
 @ConfigSerializable
 public class MaterialPropertySpec implements Cloneable {
 
-    public static final MaterialPropertySpec EMPTY = new MaterialPropertySpec();
+    public static final MaterialPropertySpec EMPTY = new MaterialPropertySpec().absent();
 
     @Setting("materialDataClass")
     public String materialDataClass;
@@ -64,6 +64,18 @@ public class MaterialPropertySpec implements Cloneable {
 
     @Setting("blockStateClass")
     public String blockStateClass;
+
+    public boolean isPresent = true;
+
+    public MaterialPropertySpec present() {
+        this.isPresent = true;
+        return this;
+    }
+
+    public MaterialPropertySpec absent() {
+        this.isPresent = false;
+        return this;
+    }
 
     @Override
     public MaterialPropertySpec clone() {


### PR DESCRIPTION
Move CB current player position store backward to avoid mixin conflict; Support constant modify of moved wrongly threshold; 
Move Material data to lazy init to avoid early usage of server instance when obtaining material data (quek04/undergarden)