### PR TITLE
Updated Trails to latest forge version + build.gradle fix

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,30 +1,42 @@
+# This workflow will build a Java project with Gradle
+# For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-gradle
+
 name: Pull Request Check
 
-on: [pull_request]
+on:
+  pull_request:
+    branches:
+      - '**'
 
 jobs:
   build:
+
     runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v2
-
-    # Update the cache action to the latest version
-    - name: Cache dependencies
+    - name: Set up JDK 17
+      uses: actions/setup-java@v1
+      with:
+        java-version: '17'
+    - name: Cache Gradle User Files
       uses: actions/cache@v3
       with:
-        path: ~/.cache
-        key: ${{ runner.os }}-build-${{ hashFiles('**/lockfiles') }}
-        restore-keys: |
-          ${{ runner.os }}-build-
-
-    - name: Set up Node.js
-      uses: actions/setup-node@v2
+        path: ~/.gradle
+        key: ${{ runner.os }}-gradle-user-home
+    - name: Cache Gradle Files
+      uses: actions/cache@v3
       with:
-        node-version: '14'
-
-    - name: Install dependencies
-      run: npm install
-
-    - name: Run tests
-      run: npm test
+        path: ./.gradle
+        key: ${{ runner.os }}-gradle-file
+    - name: Grant execute permission for gradlew
+      run: chmod +x gradlew
+    - name: Build
+      run: |
+        ./gradlew cleanBuild remapSpigotJar idea --no-daemon -i --stacktrace --refresh-dependencies
+        ./gradlew build collect --no-daemon -i --stacktrace
+    - name: Upload Artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: Arclight 
+        path: ./build/libs/*.jar

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,43 +1,30 @@
-# This workflow will build a Java project with Gradle
-# For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-gradle
-
 name: Pull Request Check
 
-on:
-  pull_request:
-    branches:
-      - '**'
+on: [pull_request]
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up JDK 17
-      uses: actions/setup-java@v1
-      with:
-        java-version: '17'
-    - name: Cache Gradle User Files
-      uses: actions/cache@v1
-      with:
-        path: ~/.gradle
-        key: ${{ runner.os }}-gradle-user-home
-    - name: Cache Gradle Files
-      uses: actions/cache@v1
-      with:
-        path: ./.gradle
-        key: ${{ runner.os }}-gradle-file
-    - name: Grant execute permission for gradlew
-      run: chmod +x gradlew
-    - name: Build
-      run: |
-        ./gradlew cleanBuild remapSpigotJar idea --no-daemon -i --stacktrace --refresh-dependencies
-        ./gradlew build collect --no-daemon -i --stacktrace
-    - name: Upload Artifact
-      uses: actions/upload-artifact@v4
-      with:
-        name: Arclight 
-        path: ./build/libs/*.jar
 
+    # Update the cache action to the latest version
+    - name: Cache dependencies
+      uses: actions/cache@v3
+      with:
+        path: ~/.cache
+        key: ${{ runner.os }}-build-${{ hashFiles('**/lockfiles') }}
+        restore-keys: |
+          ${{ runner.os }}-build-
+
+    - name: Set up Node.js
+      uses: actions/setup-node@v2
+      with:
+        node-version: '14'
+
+    - name: Install dependencies
+      run: npm install
+
+    - name: Run tests
+      run: npm test

--- a/arclight-common/build.gradle
+++ b/arclight-common/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
     repositories {
         maven { url = 'https://maven.minecraftforge.net' }
-        maven { url = 'https://repo.spongepowered.org/maven' }
+        maven { url = 'https://repo.spongepowered.org/repository/maven-public' }
         mavenCentral()
         maven { url = 'https://maven.izzel.io/releases' }
         // maven { url = 'https://maven.parchmentmc.org' }
@@ -45,7 +45,7 @@ minecraft {
 }
 
 repositories {
-    maven { url = 'https://repo.spongepowered.org/maven' }
+    maven { url = 'https://repo.spongepowered.org/repository/maven-public' }
     maven { url = 'https://oss.sonatype.org/content/repositories/snapshots/' }
     maven { url = 'https://hub.spigotmc.org/nexus/content/repositories/snapshots/' }
     maven { url = 'https://files.minecraftforge.net/maven/' }

--- a/arclight-forge/build.gradle
+++ b/arclight-forge/build.gradle
@@ -32,7 +32,7 @@ configurations {
 repositories {
     maven {
         name = 'sponge-repo'
-        url = 'https://repo.spongepowered.org/maven'
+        url = 'https://repo.spongepowered.org/repository/maven-public'
     }
     maven { url = 'https://oss.sonatype.org/content/repositories/snapshots/' }
     maven { url = 'https://hub.spigotmc.org/nexus/content/repositories/snapshots/' }

--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ allprojects {
     ext {
         agpVersion = '1.23'
         minecraftVersion = '1.20.1'
-        forgeVersion = '47.3.29'
+        forgeVersion = '47.4.0'
         apiVersion = '1.5.4'
         toolsVersion = '1.3.0'
         mixinVersion = '0.8.5'


### PR DESCRIPTION
Updated Trails to latest forge version + build.gradle fix

the old repo gives 404 while downloading jarr from the repo when you try to compile while configuring state

try cloning and building it will fail due to spone repo got some problems the public maven works
i have confirmed that i was able to build arclight trials and use it correctly :)