### PR TITLE
Port Paper block Action api

### DIFF
--- a/arclight-common/src/main/java/io/izzel/arclight/common/mixin/bukkit/ActionMixin.java
+++ b/arclight-common/src/main/java/io/izzel/arclight/common/mixin/bukkit/ActionMixin.java
@@ -1,0 +1,25 @@
+package io.izzel.arclight.common.mixin.bukkit;
+
+import org.bukkit.event.block.Action;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+
+@SuppressWarnings({"ConstantConditions", "unused"})
+@Mixin(value = Action.class, remap = false)
+public class ActionMixin {
+    // @formatter:off
+    @Shadow @Final public static Action LEFT_CLICK_AIR;
+    @Shadow @Final public static Action LEFT_CLICK_BLOCK;
+    @Shadow @Final public static Action RIGHT_CLICK_AIR;
+    @Shadow @Final public static Action RIGHT_CLICK_BLOCK;
+    // @formatter:on
+
+    public boolean isLeftClick() {
+        return (Object) this == LEFT_CLICK_AIR || (Object) this == LEFT_CLICK_BLOCK;
+    }
+
+    public boolean isRightClick() {
+        return (Object) this == RIGHT_CLICK_AIR || (Object) this == RIGHT_CLICK_BLOCK;
+    }
+}

--- a/arclight-common/src/main/resources/mixins.arclight.bukkit.json
+++ b/arclight-common/src/main/resources/mixins.arclight.bukkit.json
@@ -10,6 +10,7 @@
   },
   "compatibilityLevel": "JAVA_21",
   "mixins": [
+    "ActionMixin",
     "AsyncStructureSpawnEventMixin",
     "ColouredConsoleSenderMixin",
     "CraftAbstractVillagerMixin",


### PR DESCRIPTION
This pull request backported Paper's [Action#isLeftClick](https://jd.papermc.io/paper/1.21.5/org/bukkit/event/block/Action.html#isLeftClick()) and [Action#isRightClick](https://jd.papermc.io/paper/1.21.5/org/bukkit/event/block/Action.html#isRightClick()) to Arclight's Spigot API implementation for better plugin compatibility.

Plugins use this frequently for block events