### PR TITLE
Update neoforge to the latest version & Ars Nouveau compatibility

### DIFF
--- a/arclight-common/src/main/java/io/izzel/arclight/common/mixin/core/world/entity/LivingEntityMixin.java
+++ b/arclight-common/src/main/java/io/izzel/arclight/common/mixin/core/world/entity/LivingEntityMixin.java
@@ -667,10 +667,11 @@ public abstract class LivingEntityMixin extends EntityMixin implements LivingEnt
     @Decorate(method = "hurt", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/entity/LivingEntity;hurtHelmet(Lnet/minecraft/world/damagesource/DamageSource;F)V"))
     private void arclight$cancelHurtHelmet(LivingEntity instance, DamageSource damageSource, float f) throws
         Throwable {
-        if (entityDamageResult == null || !entityDamageResult.helmetHurtCancelled()) {
-            var result = f + entityDamageResult.armorDamageOffset();
-            if (entityDamageResult.armorDamageOffset() < 0 && result < 0) {
-                result = f + f * (entityDamageResult.armorDamageOffset() / entityDamageResult.originalArmorDamage());
+        if (entityDamageResult != null && !entityDamageResult.helmetHurtCancelled()) {
+            var armorDamageOffset = entityDamageResult.armorDamageOffset();
+            var result = f + armorDamageOffset;
+            if (armorDamageOffset < 0 && result < 0) {
+                result = f + f * (armorDamageOffset / entityDamageResult.originalArmorDamage());
             }
             if (result > 0) {
                 DecorationOps.callsite().invoke(instance, damageSource, result);

--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ allprojects {
         fabricLoaderVersion = '0.16.10'
         fabricApiVersion = '0.115.1+1.21.1'
         forgeVersion = '52.1.0'
-        neoForgeVersion = '21.1.133'
+        neoForgeVersion = '21.1.169'
         apiVersion = '1.7.3'
         toolsVersion = '1.3.0'
         mixinVersion = '0.8.5'

--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ allprojects {
         fabricLoaderVersion = '0.16.10'
         fabricApiVersion = '0.115.1+1.21.1'
         forgeVersion = '52.1.0'
-        neoForgeVersion = '21.1.169'
+        neoForgeVersion = '21.1.170'
         apiVersion = '1.7.3'
         toolsVersion = '1.3.0'
         mixinVersion = '0.8.5'

--- a/installer/src/main/java/io/izzel/arclight/installer/NeoforgeInstaller.java
+++ b/installer/src/main/java/io/izzel/arclight/installer/NeoforgeInstaller.java
@@ -87,19 +87,46 @@ public class NeoforgeInstaller {
     }
 
     private static boolean forgeClasspathMissing(Path path) throws Exception {
+        System.out.println("Checking NeoForge installation status...");
+        if (!Files.exists(path)) {
+            System.out.println("NeoForge args.txt not found, will reinstall");
+            return true;
+        }
+        
+        // Only check critical files
+        var criticalFiles = new HashSet<String>();
         for (String arg : Files.lines(path).toList()) {
             if (arg.startsWith("-p ")) {
                 var modules = arg.substring(2).trim();
-                if (!Arrays.stream(modules.split(File.pathSeparator)).map(Paths::get).allMatch(Files::exists)) {
-                    return true;
+                // Only check neoforge-related modules
+                if (modules.contains("neoforge")) {
+                    criticalFiles.add(modules);
                 }
             } else if (arg.startsWith("-DlegacyClassPath")) {
                 var classpath = arg.substring("-DlegacyClassPath=".length()).trim();
-                if (!Arrays.stream(classpath.split(File.pathSeparator)).map(Paths::get).allMatch(Files::exists)) {
+                // Only check neoforge-related jars
+                if (classpath.contains("neoforge")) {
+                    criticalFiles.add(classpath);
+                }
+            }
+        }
+        
+        // Check critical files
+        for (String file : criticalFiles) {
+            var paths = Arrays.stream(file.split(File.pathSeparator))
+                .filter(p -> p.contains("neoforge"))
+                .map(Paths::get)
+                .collect(Collectors.toList());
+                
+            for (var p : paths) {
+                if (!Files.exists(p)) {
+                    System.out.println("Critical file missing: " + p);
                     return true;
                 }
             }
         }
+        
+        System.out.println("NeoForge installation check passed");
         return false;
     }
 


### PR DESCRIPTION
Bump Neoforge version to 21.1.169
Ars Nouveau compatibility: Fixed a bug where the server crashed and threw "Fix Cannot invoke 'io.izzel.arclight.common.mod.util.EntityDamageResult.armorDamageOffset()' because 'this.entityDamageResult0' is null" when the player cast a spell