### PR TITLE
fix(entity): prevent disconnect from empty bundle packets

### DIFF
--- a/arclight-common/src/main/java/io/izzel/arclight/common/mixin/core/server/level/ServerEntityMixin.java
+++ b/arclight-common/src/main/java/io/izzel/arclight/common/mixin/core/server/level/ServerEntityMixin.java
@@ -257,7 +257,7 @@ public abstract class ServerEntityMixin implements ServerEntityBridge {
         }
     }
 
-    @Inject(method = "sendPairingData", cancellable = true, require = 0, at = @At("HEAD"))
+    @Inject(method = "addPairing", cancellable = true, require = 0, at = @At("HEAD"))
     private void arclight$returnIfRemoved(CallbackInfo ci) {
         if (this.entity.isRemoved()) {
             ci.cancel();


### PR DESCRIPTION
Fixes https://github.com/IzzelAliz/Arclight/issues/1797

This is happening because the only place "sendPairingData" is called from is addPairing:

```java
    public void addPairing(ServerPlayer p_8542_) {
        List<Packet<? super ClientGamePacketListener>> list = new ArrayList<>();
        this.sendPairingData(p_8542_, new net.neoforged.neoforge.network.bundle.PacketAndPayloadAcceptor<>(list::add));
        p_8542_.connection.send(new ClientboundBundlePacket(list));
        this.entity.startSeenByPlayer(p_8542_);
        net.neoforged.neoforge.event.EventHooks.onStartEntityTracking(this.entity, p_8542_);
    }
```

Therefore, canceling "sendPairingData" is resulting in a bundle packet being sent with an empty list, causing this disconnect.