### PR TITLE
fix(network): prevent error from spectating player/entity

### DIFF
--- a/arclight-common/src/main/java/io/izzel/arclight/common/mixin/core/network/ServerGamePacketListenerImplMixin.java
+++ b/arclight-common/src/main/java/io/izzel/arclight/common/mixin/core/network/ServerGamePacketListenerImplMixin.java
@@ -1690,7 +1690,6 @@ public abstract class ServerGamePacketListenerImplMixin extends ServerCommonPack
             PlayerTeleportEvent event = new PlayerTeleportEvent(player, from.clone(), to.clone(), cause);
             this.cserver.getPluginManager().callEvent(event);
             if (event.isCancelled() || !to.equals(event.getTo())) {
-                relativeSet.clear();
                 to = (event.isCancelled() ? event.getFrom() : event.getTo());
                 x = to.getX();
                 y = to.getY();


### PR DESCRIPTION
Fixes a server crash caused by clicking another player (to set your camera to their entity) when in spectator.

I'm not sure if this change will cause any breakages with cancelling, or modifying, the PlayerTeleportEvent. However, you cannot clear the relativeSet parameter as in multiple places it is being passed in as an unmodifiable set.

Steps:
1. Go into gamemode spectator
2. Right click a second player that is flying
3. Server crashes

Crash report:
https://paste.helpch.at/alidacanut