### PR TITLE
Update Minecraft dependencies to latest versions

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -29,11 +29,11 @@ mixin-tools = '1.2.6'
 # minecraft, loaders dependencies (CHECK when migrating Minecraft Versions)
 minecraft = '1.21.1'
 parchment = '2024.11.17'
-forge = '52.1.5'
-full-forge = '1.21.1-52.1.5'
-fabric-loader = '0.18.2'
-fabric-api = '0.116.7+1.21.1'
-neoforge = '21.1.216'
+forge = '52.1.10'
+full-forge = '1.21.1-52.1.10'
+fabric-loader = '0.18.4'
+fabric-api = '0.116.9+1.21.1'
+neoforge = '21.1.219'
 fabric-permissions-api = '0.3.1'
 
 # spigot dependencies (CHECK when migrating Spigot Versions)


### PR DESCRIPTION
Updating modloaders to their latest version as of March 11th 2026