### PR TITLE
fix: prevent PacketRecorder NPE on null payload ids

### DIFF
--- a/arclight-common/src/main/java/io/izzel/arclight/common/mod/plugin/messaging/PacketRecorder.java
+++ b/arclight-common/src/main/java/io/izzel/arclight/common/mod/plugin/messaging/PacketRecorder.java
@@ -16,7 +16,7 @@ public class PacketRecorder {
         unknown.defaultReturnValue(0);
     }
 
-    public void recordUnknown(ResourceLocation id) {
+    public synchronized void recordUnknown(ResourceLocation id) {
         if (id == null) {
             ArclightServer.LOGGER.debug("Received packet with null id. This should never happen.");
             return;
@@ -25,7 +25,7 @@ public class PacketRecorder {
         unknown.put(id, num + 1);
     }
 
-    public void update() {
+    public synchronized void update() {
         long now = Util.getMillis();
         if (Math.abs(now - lastUpdate) > ArclightConstants.PACKET_RECORDER_PERIOD_SEC *1000) {
             consumeAndLog();
@@ -33,8 +33,15 @@ public class PacketRecorder {
         }
     }
 
-    public void consumeAndLog() {
+    public synchronized void consumeAndLog() {
         String unknowns = unknown.object2IntEntrySet().stream()
+                .filter(it -> {
+                    if (it.getKey() == null) {
+                        ArclightServer.LOGGER.warn("Packet recorder encountered a null payload id entry; skipping corrupted record.");
+                        return false;
+                    }
+                    return true;
+                })
                 .map(it -> it.getKey().toString() + '(' + it.getIntValue() + ')')
                 .collect(Collectors.joining(", ", "unknown=[", "];"));
         unknown.clear();


### PR DESCRIPTION
fixes #2111 