### PR TITLE
Fix Create Mod schematic cannons

### DIFF
--- a/arclight-common/src/main/java/io/izzel/arclight/common/mixin/core/world/level/LevelMixin.java
+++ b/arclight-common/src/main/java/io/izzel/arclight/common/mixin/core/world/level/LevelMixin.java
@@ -285,6 +285,10 @@ public abstract class LevelMixin implements WorldBridge, LevelAccessor, LevelWri
 
     @Override
     public boolean bridge$addEntity(Entity entity, CreatureSpawnEvent.SpawnReason reason) {
+        if (this.world == null) {
+            return this.addFreshEntity(entity);
+        }
+
         if (getWorld().getHandle() != (Object) this) {
             return ((WorldBridge) getWorld().getHandle()).bridge$addEntity(entity, reason);
         } else {
@@ -295,6 +299,8 @@ public abstract class LevelMixin implements WorldBridge, LevelAccessor, LevelWri
 
     @Override
     public void bridge$pushAddEntityReason(CreatureSpawnEvent.SpawnReason reason) {
+        if (this.world == null) return;
+
         if (getWorld().getHandle() != (Object) this) {
             ((WorldBridge) getWorld().getHandle()).bridge$pushAddEntityReason(reason);
         }
@@ -302,6 +308,8 @@ public abstract class LevelMixin implements WorldBridge, LevelAccessor, LevelWri
 
     @Override
     public CreatureSpawnEvent.SpawnReason bridge$getAddEntityReason() {
+        if (this.world == null) return null;
+
         if (getWorld().getHandle() != (Object) this) {
             return ((WorldBridge) getWorld().getHandle()).bridge$getAddEntityReason();
         }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -33,7 +33,7 @@ forge = '52.1.5'
 full-forge = '1.21.1-52.1.5'
 fabric-loader = '0.18.2'
 fabric-api = '0.116.7+1.21.1'
-neoforge = '21.1.216'
+neoforge = '21.1.225'
 fabric-permissions-api = '0.3.1'
 
 # spigot dependencies (CHECK when migrating Spigot Versions)


### PR DESCRIPTION
Create uses fake worlds for their contraptions, so there are some situations in which arclight tries to send bukkit events with a null CraftWorld. I'm not entirely sure why this only happens with schematic cannons, especially with them not being contraptions, but the symptom is that loading schematics will crash. 

I also bumped the neoforge version for general compatibility with mods like aeronautics.