### PR TITLE
Fix NullPointerException in handleChat when ServerChatEvent is cancelled

### DIFF
--- a/arclight-common/src/main/java/io/izzel/arclight/common/mixin/core/network/ServerPlayNetHandlerMixin.java
+++ b/arclight-common/src/main/java/io/izzel/arclight/common/mixin/core/network/ServerPlayNetHandlerMixin.java
@@ -1023,7 +1023,9 @@ public abstract class ServerPlayNetHandlerMixin implements ServerPlayNetHandlerB
 
                 this.chatMessageChain.append((executor) -> {
                     return CompletableFuture.allOf(completablefuture, completablefuture1).thenAcceptAsync((ovoid) -> {
-                        PlayerChatMessage playerchatmessage1 = playerchatmessage.withUnsignedContent(completablefuture1.join()).filter(completablefuture.join().mask());
+                        Component decoratedContent = completablefuture1.join();
+                        if (decoratedContent == null) return; // Forge: ServerChatEvent was cancelled
+                        PlayerChatMessage playerchatmessage1 = playerchatmessage.withUnsignedContent(decoratedContent).filter(completablefuture.join().mask());
 
                         this.broadcastChatMessage(playerchatmessage1);
                     }, ArclightServer.getChatExecutor()); // CraftBukkit - async chat


### PR DESCRIPTION

### Problem

Every chat message triggers a `NullPointerException` in `PlayerChatMessage.withUnsignedContent()`:

```
java.lang.NullPointerException: Cannot invoke "Object.equals(Object)" because "p_242164_" is null
    at net.minecraft.server.network.chat.PlayerChatMessage.m_241956_(PlayerChatMessage.java:44)
    at net.minecraft.server.network.ServerGamePacketListenerImpl.md91c34f$lambda$handleChat$5(ServerPlayNetHandlerMixin.java:2811)
```

This occurs when mods like **NoChatReports** interact with the chat pipeline, and is reproducible on every single chat message.

### Root Cause

Forge's vanilla-patched `handleChat()` includes a null-check for the decorated content returned by `ServerChatEvent`:

```java
Component decoratedContent = completablefuture1.join();
if (decoratedContent == null)
    return; // Forge: ServerChatEvent was cancelled
```

Arclight's `@Overwrite` of `handleChat()` in `ServerPlayNetHandlerMixin` is missing this null-check, passing `null` directly into `PlayerChatMessage.withUnsignedContent()`, which calls `.equals()` on the null value.

### Fix

Add the null-check from Forge's patch before calling `withUnsignedContent()`

### Environment

- Arclight Trials (1.20.1) / Forge 47.4.18
- NoChatReports-FORGE-1.20.1-v2.2.2
- ~300 mods
